### PR TITLE
Add shot ID to exported file

### DIFF
--- a/ui/tabs/elm_tab.py
+++ b/ui/tabs/elm_tab.py
@@ -78,7 +78,7 @@ def generate_elm_tab(shot_id: str):
             zone_data = elm_analysis.get_zone_data()
             csv_data = elm_data.to_csv(index=False)
             csv_data += "\n" + zone_data.to_csv(index=False)
-            st.download_button(label="Download Data", data=csv_data, file_name="ELM_Data.csv")
+            st.download_button(label="Download Data", data=csv_data, file_name=f"ELM_Data_{shot_id}.csv")
 
         download_data()
 

--- a/ui/tabs/h_mode_tab.py
+++ b/ui/tabs/h_mode_tab.py
@@ -40,7 +40,7 @@ def generate_h_mode_tab(shot_id: str):
         def download_data():
             zone_data = h_mode_analysis.get_zone_data()
             csv_data = zone_data.to_csv(index=False)
-            st.download_button(label="Download Data", data=csv_data, file_name="HMode_Data.csv")
+            st.download_button(label="Download Data", data=csv_data, file_name=f"HMode_Data_{shot_id}.csv")
 
         download_data()
 


### PR DESCRIPTION
A requested feature to append the shot ID to the exported file name to speed up data annotation