### PR TITLE
Fix docker file trying to copy inexistent file

### DIFF
--- a/services/ui/Dockerfile
+++ b/services/ui/Dockerfile
@@ -4,8 +4,8 @@ FROM node:18-alpine
 # Set working directory inside the container
 WORKDIR /app
 
-# Copy package.json and yarn.lock first (to optimize caching)
-COPY package.json yarn.lock ./
+# Copy package.json first (to optimize caching)
+COPY package.json ./
 
 # Install dependencies using Yarn
 RUN yarn install --frozen-lockfile


### PR DESCRIPTION
This fixes an issue that happens the very first time you try to build the images due to a missing `yarn.lock` file.

`yarn.lock` is generated by the `yarn install` command, but the `Dockerfile` assumed that this file should exist and be copied before `yarn install` - this lead to `docker compose up` exiting with an error the very first time you tried things out (does not seem to happen for subsequent attempts):

<img width="1117" alt="image" src="https://github.com/user-attachments/assets/20e2c78c-7ceb-4e17-803d-4c392a60de07" />

<img width="720" alt="image" src="https://github.com/user-attachments/assets/b8d69815-eac0-4281-bd99-988ef0fa8416" />
