### PR TITLE
Fix #11 – Eliminate duplicate zones/disruptions in dev mode

### DIFF
--- a/services/ui/src/app/components/providers/vpsan-provider.tsx
+++ b/services/ui/src/app/components/providers/vpsan-provider.tsx
@@ -72,13 +72,16 @@ export const VSpanProvider = ({categories, initialData, children} : {
 
     // Initialisation of data - this should only run once
     useEffect(() => {
-        if (!initialData) return
-
-        for (const span of initialData) {
-            spans.current.push(span)
-        }
-        triggerVSpanUpdate()
-    }, [initialData])
+        if (!initialData) return;
+    
+        spans.current = [...initialData]; 
+        triggerVSpanUpdate();
+    
+        /* cleanup runs when the first (discarded) mount unmounts */
+        return () => {
+          spans.current = [];
+        };
+      }, [initialData]);
 
     // Provides an array of the categories for the context menu
     const updateTypeItems = categories.map((category, index) => {

--- a/services/ui/src/app/components/providers/zone-provider.tsx
+++ b/services/ui/src/app/components/providers/zone-provider.tsx
@@ -75,14 +75,19 @@ export const ZoneProvider = ({categories, initialData, children} : {
     }
 
     // Initialisation of data - this should only run once
+    // Effect: run ONCE per mount to populate from initialData
+    // – overwrites instead of pushing; cleans on unmount
     useEffect(() => {
-        if (!initialData) return
-
-        for (const zone of initialData) {
-            zones.current.push(zone)
-        }
-        triggerZoneUpdate()
-    }, [initialData])
+        if (!initialData) return;
+    
+        zones.current = [...initialData]; 
+        triggerZoneUpdate();
+    
+        /* remove stale copy when Strict-Mode unmounts the first render */
+        return () => {
+          zones.current = [];
+        };
+      }, [initialData]);
 
     // Provides an array of the categories for the context menu
     const updateTypeItems = categories.map((category, index) => {

--- a/services/ui/src/app/disruption/components/disruption-plot.tsx
+++ b/services/ui/src/app/disruption/components/disruption-plot.tsx
@@ -127,8 +127,8 @@ export const DisruptionPlot = ({data, plotId: externalId, zoneCategories, disrup
         initGraph()
         
         return () => { // cleanup on unmount / Fast-Refresh
-            plotElement?.removeAllListeners?.("plotly_relayout") // detach relayout listener
-            ;(window as any).Plotly?.purge?.(root) //  fully purge plotly figure
+            plotElement?.removeAllListeners?.("plotly_relayout"); // detach relayout listener
+            (window as any).Plotly?.purge?.(root);                // fully purge plotly figure
             root?.querySelector(`.${plotId}-overplot`)?.remove() // remove custom overlay group
             setPlotReady(false) // reset ready state
         } 

--- a/services/ui/src/app/disruption/components/disruption-plot.tsx
+++ b/services/ui/src/app/disruption/components/disruption-plot.tsx
@@ -128,9 +128,8 @@ export const DisruptionPlot = ({data, plotId: externalId, zoneCategories, disrup
         
         return () => { // cleanup on unmount / Fast-Refresh
             plotElement?.removeAllListeners?.("plotly_relayout"); // detach relayout listener
-            (window as any).Plotly?.purge?.(root);                // fully purge plotly figure
-            root?.querySelector(`.${plotId}-overplot`)?.remove() // remove custom overlay group
-            setPlotReady(false) // reset ready state
+            root?.querySelector(`.${plotId}-overplot`)?.remove(); // remove custom overlay group
+            setPlotReady(false); // reset ready state
         } 
     }, [plotId])
 

--- a/services/ui/src/app/disruption/components/disruption-plot.tsx
+++ b/services/ui/src/app/disruption/components/disruption-plot.tsx
@@ -95,17 +95,21 @@ export const DisruptionPlot = ({data, plotId: externalId, zoneCategories, disrup
             modeBarButtonsToRemove: ['toImage', 'zoom2d', 'zoomIn2d', 'zoomOut2d', 'autoScale2d'],
         }
 
+        let plotElement: Plotly.PlotlyHTMLElement | null = null // holds the created plot for later cleanup
+
         const initGraph = async () => {
             const { react } = await import('plotly.js') // Annoyingly there seems to be an issue with plotly so dynamic import is needed
 
             react(root, plotData, plotLayout, plotConfig).then((plot: Plotly.PlotlyHTMLElement) => {
+                plotElement = plot // save reference to remove listeners later
+
                 const subplot = plot.querySelector(".overplot")?.querySelector(".xy") as HTMLElement
                 if (!subplot) {
                     console.error("Cannot locate disruption plotly subplot")
                     return
                 }
 
-                if (document.getElementsByClassName(`${plotId}-overplot`).length === 0) {
+                if (!subplot.querySelector(`.${plotId}-overplot`)) { // ensure only one custom overlay group is present
                     const svg = document.createElementNS("http://www.w3.org/2000/svg", "g")
                     svg.setAttribute("class", `${plotId}-overplot`)
                     svg.setAttribute("fill", "none");
@@ -114,13 +118,20 @@ export const DisruptionPlot = ({data, plotId: externalId, zoneCategories, disrup
 
                 setPlotReady(true)
 
-                plot.on("plotly_relayout", () => {
+                const relayoutHandler = () => { // triggers re-render of overlay tools when axes change
                     triggerToolUpdate()
-                })
+                } 
+                plot.on("plotly_relayout", relayoutHandler) // attach listener so it can be removed
             })
         }
         initGraph()
         
+        return () => { // cleanup on unmount / Fast-Refresh
+            plotElement?.removeAllListeners?.("plotly_relayout") // detach relayout listener
+            ;(window as any).Plotly?.purge?.(root) //  fully purge plotly figure
+            root?.querySelector(`.${plotId}-overplot`)?.remove() // remove custom overlay group
+            setPlotReady(false) // reset ready state
+        } 
     }, [plotId])
 
     // Handles context menu creation
@@ -159,9 +170,15 @@ export const DisruptionPlot = ({data, plotId: externalId, zoneCategories, disrup
             return
         }
 
-        dragElement.addEventListener("contextmenu", (event) => {
+        const contextHandler = (event) => { //  wrap handler so we can remove it
             handleContextMenu(event, plot)
-        })
+        } 
+
+        dragElement.addEventListener("contextmenu", contextHandler) // add context-menu listener
+
+        return () => { // remove listener on effect cleanup
+            dragElement.removeEventListener("contextmenu", contextHandler) 
+        }
 
     }, [plotId, plotReady])
 


### PR DESCRIPTION
This PR resolves the “Disruption table rendering duplicate values and click-to-hide not working” bug (#11).
The root cause was React 18 Strict-Mode mounting components twice during Fast-Refresh, causing our initialisation Effects to run twice and leaving extra Plotly elements on the page.

**Summary of changes:**

- React Strict-Mode mounted components twice, our effects added state on each mount and never cleaned up, so duplicates appeared on refresh/Fast-Refresh.

- zone-provider.tsx: initialise with zones.current = [...initialData]; clear in effect cleanup → no duplicate horizontal bars or table rows.

- vpsan-provider.tsx: same overwrite + cleanup pattern for disruption v-spans → no duplicate red lines/rows.

- disruption-plot.tsx: keep a plotElement reference, detach plotly_relayout, Plotly.purge(root), remove custom <g> overlay, and clean the context-menu listener on unmount.

**Result**: single set of tools after refresh, no leaked SVG groups or listeners, lower memory; production behaviour unchanged.

**Verification**: tested manual refresh and repeated Fast-Refresh on /disruption/26599; duplicates gone and console clean.

[issue11AFTER.webm](https://github.com/user-attachments/assets/a29147e1-bd9e-435a-a708-9e3b3bc328ed)
