### PR TITLE
Remove scroll-based zooming to prevent flickering issue

### DIFF
--- a/services/ui/src/app/disruption/components/disruption-plot.tsx
+++ b/services/ui/src/app/disruption/components/disruption-plot.tsx
@@ -91,8 +91,7 @@ export const DisruptionPlot = ({data, plotId: externalId, zoneCategories, disrup
         const plotConfig: Partial<Plotly.Config> = {
             displaylogo: false,
             displayModeBar: true,
-            scrollZoom: true,
-            modeBarButtonsToRemove: ['toImage', 'zoom2d', 'zoomIn2d', 'zoomOut2d', 'autoScale2d'],
+            scrollZoom: false,
         }
 
         let plotElement: Plotly.PlotlyHTMLElement | null = null // holds the created plot for later cleanup


### PR DESCRIPTION
**Rationale**
Scroll-based zooming causes the D3 overplot tooling to flicker due to a mismatch in update timing

**Changes**

- Disabled scoll-based zooming
- Enabled tool based zooming in plotly toolbar

A feature issue will be created to attempt to bring back scrolling in the future