### PR TITLE
Bug fix: Plot zooming

### DIFF
--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -105,13 +105,35 @@ export const TimeSeries = ({
                     triggerToolUpdate()
                 } 
                 plot.on("plotly_relayout", relayoutHandler) // attach listener so it can be removed
+
+                document.addEventListener("keydown", (e) => {
+                    if (e.key === "Shift") {
+                        const elements = plot.querySelectorAll(".disable-on-shift")
+                        elements.forEach((element) => {
+                            element.setAttribute("style", "pointer-events: none")
+                        })
+                    }
+                })
+
+                document.addEventListener("keyup", (e) => {
+                    if (e.key === "Shift") {
+                        const elements = plot.querySelectorAll(".disable-on-shift")
+                        elements.forEach((element) => {
+                            element.setAttribute("style", "pointer-events: all")
+                        })
+                    }
+                })
             })
         }
         initGraph()
         
         return () => { // cleanup on unmount / Fast-Refresh
-            console.log("Clean up")
             plotElement?.removeAllListeners?.("plotly_relayout"); // detach relayout listener
+
+            // detach key press listeners
+            plotElement?.removeAllListeners?.("keydown");
+            plotElement?.removeAllListeners?.("keyup");
+
             overplots.forEach(overplot => {
                 root?.querySelector(`.${overplot}`)?.remove(); // remove custom overlay group
             })

--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -36,7 +36,7 @@ export const TimeSeries = ({
         config = {
             displaylogo: false,
             displayModeBar: true,
-            scrollZoom: true
+            scrollZoom: false
         }
     }, 
     children

--- a/services/ui/src/app/components/tools/vspans.tsx
+++ b/services/ui/src/app/components/tools/vspans.tsx
@@ -103,7 +103,7 @@ export const VSpans = ({plotId, plotReady, forceUpdate} : ToolingProps) => {
             for (const vspan of vspans) {
                 const x = xaxis.d2p(vspan.x);
                 graphGroup.append("line")
-                    .attr("class", "vspan")
+                    .attr("class", "vspan disable-on-shift")
                     .attr("x1", x)
                     .attr("x2", x)
                     .attr("y1", upperLimit)
@@ -114,7 +114,7 @@ export const VSpans = ({plotId, plotReady, forceUpdate} : ToolingProps) => {
                     .style("cursor", "move")
 
                 graphGroup.append("rect")
-                    .attr("class", "vspan")
+                    .attr("class", "vspan disable-on-shift")
                     .attr("x", x-10)
                     .attr("y", upperLimit)
                     .attr("width", 20)

--- a/services/ui/src/app/components/tools/zones.tsx
+++ b/services/ui/src/app/components/tools/zones.tsx
@@ -28,7 +28,6 @@ export const Zones = ({
 
     // Main rendering effect
     useEffect(() => {
-        console.log("Render Zones: ", plotReady, plotId)
         // This shall not run until the target plot is initialised
         if (!plotId || !plotReady || forceUpdate === undefined) {
             return

--- a/services/ui/src/app/components/tools/zones.tsx
+++ b/services/ui/src/app/components/tools/zones.tsx
@@ -128,7 +128,7 @@ export const Zones = ({
                 const x0 = xaxis.d2p(zone.x0);
                 const x1 = xaxis.d2p(zone.x1);
                 graphGroup.append("rect")
-                    .attr("class", "zone span cursor-grab")
+                    .attr("class", "zone span cursor-grab disable-on-shift")
                     .attr("x", x0)
                     .attr("y", upperLimit)
                     .attr("width", x1 - x0)
@@ -142,7 +142,7 @@ export const Zones = ({
                     .on("contextmenu", handleContextMenu)
 
                 graphGroup.append("rect")
-                    .attr("class", "zone leftHandle")
+                    .attr("class", "zone leftHandle disable-on-shift")
                     .attr("x", x0-10)
                     .attr("y", upperLimit)
                     .attr("width", 20)
@@ -154,7 +154,7 @@ export const Zones = ({
                     .call(getBoundaryHandler(true))
 
                 graphGroup.append("rect")
-                    .attr("class", "zone rightHandle")
+                    .attr("class", "zone rightHandle disable-on-shift")
                     .attr("x", x1-10)
                     .attr("y", upperLimit)
                     .attr("width", 20)


### PR DESCRIPTION
### Bug Report
It was reported that zooming had been re-enabled as part of the transition to the standard time series component. It was agreed previously that scroll to zoom should be disabled due to flickering issues. Since this is a low priority task, time has not yet been allocated to investigate the issue

Whilst investigating, it was also noticed that the handling of default plotly navigation functions using the shift key were not handled correctly by the tooling overlay.

### Fixes

- The scroll to zoom feature has been disabled again to prevent flickering
- The shift key modifier now suspends tooling pointer events to allow default plotly interactions
- Standardised approach now implemented to allow other keys to disabled pointer events

### Future Improvements

- An issue already exists to reintroduce zooming when time is available to investigate a solution


https://github.com/user-attachments/assets/7f105ead-ed89-47ff-872e-8561ea7f6e93

