### PR TITLE
Add support for saving/loading VSpan annotations

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional
 import requests
 
 
@@ -34,7 +35,12 @@ def create_uda_samples(project_id: str, shot_ids: list[int]):
     requests.put(f"http://localhost:8002/projects/{project_id}/samples", json=samples)
 
 
-def create_local_samples(project_id: str, shot_ids: list[int], base_path: str):
+def create_local_samples(
+    project_id: str,
+    shot_ids: list[int],
+    base_path: str,
+    columns: Optional[list[str]] = None,
+):
     samples = []
 
     base_path = Path(base_path)
@@ -46,6 +52,7 @@ def create_local_samples(project_id: str, shot_ids: list[int], base_path: str):
                 "file_name": str(base_path / f"{shot_id}.parquet"),
                 "type": "parquet",
                 "protocol": "file",
+                "column_names": columns,
             },
         }
         samples.append(sample)
@@ -69,7 +76,9 @@ def main():
     shot_ids = [int(path.stem) for path in shot_files]
 
     project_id = create_project("Local MHD Project", "MHD", "parquet")
-    create_local_samples(project_id, shot_ids, base_path="/data/test/mhd")
+    create_local_samples(
+        project_id, shot_ids, base_path="/data/test/mhd", columns=["mirnov"]
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -34,15 +34,16 @@ def create_uda_samples(project_id: str, shot_ids: list[int]):
     requests.put(f"http://localhost:8002/projects/{project_id}/samples", json=samples)
 
 
-def create_local_samples(project_id: str, shot_ids: list[int], shot_files: list[Path]):
+def create_local_samples(project_id: str, shot_ids: list[int], base_path: str):
     samples = []
 
-    for shot_id, path in zip(shot_ids, shot_files):
+    base_path = Path(base_path)
+    for shot_id in shot_ids:
         sample = {
             "project_id": project_id,
             "shot_id": shot_id,
             "data": {
-                "file_name": f"/data/test/summary/{shot_id}.parquet",
+                "file_name": str(base_path / f"{shot_id}.parquet"),
                 "type": "parquet",
                 "protocol": "file",
             },
@@ -61,7 +62,14 @@ def main():
     create_uda_samples(project_id, shot_ids)
 
     project_id = create_project("Local ELM Project", "ELM", "parquet")
-    create_local_samples(project_id, shot_ids, shot_files)
+    create_local_samples(project_id, shot_ids, base_path="/data/test/summary")
+
+    shot_files = Path("./data/test/mhd").glob("*.parquet")
+    shot_files = list(shot_files)
+    shot_ids = [int(path.stem) for path in shot_files]
+
+    project_id = create_project("Local MHD Project", "MHD", "parquet")
+    create_local_samples(project_id, shot_ids, base_path="/data/test/mhd")
 
 
 if __name__ == "__main__":

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -74,7 +74,6 @@ def main():
     shot_files = Path("./data/test/mhd").glob("*.parquet")
     shot_files = list(shot_files)
     shot_ids = [int(path.stem) for path in shot_files]
-
     project_id = create_project("Local MHD Project", "MHD", "parquet")
     create_local_samples(
         project_id, shot_ids, base_path="/data/test/mhd", columns=["mirnov"]

--- a/services/api/core/annotators.py
+++ b/services/api/core/annotators.py
@@ -25,8 +25,8 @@ class FindPeaksAnnotator:
         self.params = params
 
     def predict(self, data: MultiVariateTimeSeriesData) -> list[TimeRegion]:
-        time = np.array(data.values["dalpha"].time)
-        signal = data.values["dalpha"].values
+        time = np.array(data.values[self.params.signal_name].time)
+        signal = data.values[self.params.signal_name].values
         signal = np.array(signal)
 
         tmin, tmax = self.params.time_min, self.params.time_max

--- a/services/api/core/data_loaders.py
+++ b/services/api/core/data_loaders.py
@@ -1,3 +1,4 @@
+from typing import Union
 import pandas as pd
 
 from abc import ABC, abstractmethod
@@ -9,7 +10,7 @@ from services.api.schemas.data import (
     TimeSeriesData,
     ImageData,
 )
-from services.api.schemas.samples import FileData, Sample, ShotData
+from services.api.schemas.samples import FileData, Sample, ShotData, TimeSeriesFileData
 from services.api.schemas.projects import DataLoaderType
 
 
@@ -35,8 +36,8 @@ class ParquetDataLoader(DataLoader):
     """DataLoader for retrieving data using a folder of Parquet files"""
 
     def get_sample(self, sample: Sample) -> MultiVariateTimeSeriesData:
-        item: FileData = sample.data
-        df = pd.read_parquet(item.file_name)
+        item: TimeSeriesFileData = sample.data
+        df = pd.read_parquet(item.file_name, columns=item.column_names)
         # df = df[item.column_names]
         df = df.fillna(0)
         data = df.to_dict("list")

--- a/services/api/core/views.py
+++ b/services/api/core/views.py
@@ -45,7 +45,7 @@ class SpectrogramView:
             values,
             fs=int(sample_rate),
             nperseg=self.params.nperseg,
-            noverlap=self.params.nperseg // 5,
+            noverlap=self.params.nperseg // 2,
         )
         values = np.absolute(values)
 
@@ -68,14 +68,26 @@ class SpectrogramView:
             else freq.max()
         )
 
+        amplitude_min = (
+            self.params.amplitude_min
+            if self.params.amplitude_min is not None
+            else values.min()
+        )
+        amplitude_max = (
+            self.params.amplitude_max
+            if self.params.amplitude_max is not None
+            else values.max()
+        )
+
         ds = xr.DataArray(values, coords=dict(frequency=freq, time=time))
         ds = ds.sel(time=slice(time_min, time_max))
         ds = ds.sel(frequency=slice(frequency_min, frequency_max))
+        ds = ds.clip(amplitude_min, amplitude_max)
 
         return SpectrogramData(
             time=ds.time.values.tolist(),
             frequency=ds.frequency.values.tolist(),
-            values=ds.values.tolist(),
+            amplitude=ds.values.tolist(),
         )
 
 

--- a/services/api/core/views.py
+++ b/services/api/core/views.py
@@ -41,13 +41,15 @@ class SpectrogramView:
 
         # Compute the Short-Time Fourier Transform (STFT)
         sample_rate = 1 / (time[1] - time[0])
-        freq, time, values = stft(
+        freq, ts, values = stft(
             values,
             fs=int(sample_rate),
             nperseg=self.params.nperseg,
             noverlap=self.params.nperseg // 2,
         )
         values = np.absolute(values)
+        freq /= 1000
+        time = ts + time[0]
 
         # Clip to time/frequency range
         time_min = (

--- a/services/api/core/views.py
+++ b/services/api/core/views.py
@@ -1,0 +1,82 @@
+import numpy as np
+import xarray as xr
+from scipy.signal import stft
+from services.api.schemas.data import (
+    CompositeData,
+    MultiVariateTimeSeriesData,
+    SpectrogramData,
+    Data,
+    TimeSeriesData,
+)
+from services.api.schemas.views import SpectrogramViewParams, ViewParams, ViewType
+
+
+class IdentityView:
+    def __init__(self, params: ViewParams):
+        self.params = params
+
+    def __call__(self, data: Data):
+        return data
+
+
+class SpectrogramView:
+    def __init__(self, params: SpectrogramViewParams):
+        self.params = params
+
+    def __call__(self, data: Data) -> Data:
+        if isinstance(data, MultiVariateTimeSeriesData):
+            response = {}
+            for key, value in data.values.items():
+                response[key] = self.convert_timeseries_to_spectrogram(value)
+        else:
+            raise RuntimeError(f"Unsupported data type: {type(data)}")
+
+        return CompositeData(values=response)
+
+    def convert_timeseries_to_spectrogram(
+        self, data: TimeSeriesData
+    ) -> SpectrogramData:
+        time = np.array(data.time)
+        values = np.array(data.values)
+
+        # Compute the Short-Time Fourier Transform (STFT)
+        sample_rate = 1 / (time[1] - time[0])
+        freq, time, values = stft(
+            values,
+            fs=int(sample_rate),
+            nperseg=self.params.nperseg,
+            noverlap=self.params.nperseg // 5,
+        )
+        values = np.absolute(values)
+
+        # Clip to time/frequency range
+        time_min = (
+            self.params.time_min if self.params.time_min is not None else time.min()
+        )
+        time_max = (
+            self.params.time_max if self.params.time_max is not None else time.max()
+        )
+
+        frequency_min = (
+            self.params.frequency_min
+            if self.params.frequency_min is not None
+            else freq.min()
+        )
+        frequency_max = (
+            self.params.frequency_max
+            if self.params.frequency_max is not None
+            else freq.max()
+        )
+
+        ds = xr.DataArray(values, coords=dict(frequency=freq, time=time))
+        ds = ds.sel(time=slice(time_min, time_max))
+        ds = ds.sel(frequency=slice(frequency_min, frequency_max))
+
+        return SpectrogramData(
+            time=ds.time.values.tolist(),
+            frequency=ds.frequency.values.tolist(),
+            values=ds.values.tolist(),
+        )
+
+
+DATA_VIEWS = {ViewType.IDENTITY: IdentityView, ViewType.SPECTROGRAM: SpectrogramView}

--- a/services/api/routers/annotations.py
+++ b/services/api/routers/annotations.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Request, HTTPException, Path, Query
 from services.api.crud import utils
 from services.api.schemas.samples import Sample
 from services.api.schemas.annotators import Annotator
-from services.api.schemas.annotations import AnnotationIn, Annotation
+from services.api.schemas.annotations import AnnotationIn, Annotation, AnnotationTypes
 from services.api.schemas import convert_to_objectid
 
 router = APIRouter(
@@ -78,7 +78,7 @@ async def delete_all_annotations(
 
 @router.get(
     "/samples/{sample_id}/annotations",
-    response_model=list[Annotation],
+    response_model=list[AnnotationTypes],
     responses={
         200: {"description": "Annotations for this sample retrieved successfully."},
         404: {"description": "Project or Sample not found with that ID."},
@@ -128,6 +128,7 @@ async def get_annotations(
         start=start,
         limit=end - start + 1 if end is not None else 0,
     )
+    print(_annotations)
 
     return _annotations
 
@@ -141,7 +142,7 @@ async def get_annotations(
 )
 async def add_annotations(
     request: Request,
-    annotations: list[AnnotationIn],
+    annotations: list[AnnotationTypes],
     project_id: str = Path(description="The ID of the project to add annotations for."),
     sample_id: str = Path(description="The ID of the sample to add annotations for."),
 ):
@@ -158,6 +159,11 @@ async def add_annotations(
         "project_id": convert_to_objectid(project_id, "projects"),
         "sample_id": convert_to_objectid(sample_id, "samples"),
     }
+
+    print(annotations)
+    if len(annotations) == 0:
+        # Nothing to do!
+        return
 
     if not await request.app.state.db_client.get_document_by_id(
         "projects", ids["project_id"]

--- a/services/api/routers/annotations.py
+++ b/services/api/routers/annotations.py
@@ -45,6 +45,7 @@ async def get_all_annotations(
     annotations = await utils.get_annotations(
         db_client, project_id, validated, start, end
     )
+    print(annotations)
     return annotations
 
 

--- a/services/api/routers/data.py
+++ b/services/api/routers/data.py
@@ -1,38 +1,43 @@
 from fastapi import APIRouter, Request, HTTPException
-from services.api.schemas.data import (
-    Data,
-    ImageData,
-    MultiVariateTimeSeriesData,
-)
-from typing import Union
-from services.api.schemas.samples import Sample
+from typing import Optional
 from services.api.core.data_loaders import DATA_LOADERS
+from services.api.core.views import DATA_VIEWS
 from services.api.crud import utils
+from services.api.schemas.samples import Sample
+from services.api.schemas.data import DataResponseType
+from services.api.schemas.views import ViewParams, ViewParamTypes
 
-DataResponseType = Union[Data, ImageData, MultiVariateTimeSeriesData]
 
 router = APIRouter(
     prefix="/projects/{project_id}/samples/{sample_id}/data", tags=["Data"]
 )
 
 
-@router.get("", response_model=DataResponseType)
+@router.post("", response_model=DataResponseType)
 async def get_data(
-    request: Request, project_id: str, sample_id: str
+    request: Request,
+    project_id: str,
+    sample_id: str,
+    view: Optional[ViewParamTypes] = ViewParams(),
 ) -> DataResponseType:
     """Get data, e.g. time trace, about the given sample required for the given project"""
     db_client = request.app.state.db_client
     project = await utils.get_project(db_client, project_id)
     sample = await utils.get_sample(db_client, sample_id)
+
     data_loader = DATA_LOADERS[project.data_loader]()
-    data_item = data_loader.get_sample(sample)
-    return data_item
+    data = data_loader.get_sample(sample)
+
+    data_view = DATA_VIEWS[view.name](view)
+    data = data_view(data)
+
+    return data
 
 
 @router.put("")
 async def add_data(
     project_id: str, sample_id: str, request: Request
-) -> Union[Data, ImageData]:
+) -> DataResponseType:
     """
     Endpoint not implemented
     ------------------------
@@ -46,7 +51,7 @@ async def add_data(
 @router.delete("")
 async def delete_data(
     project_id: str, sample_id: str, params: Sample = None
-) -> Union[Data, ImageData]:
+) -> DataResponseType:
     """
     Endpoint not implemented
     ------------------------

--- a/services/api/schemas/annotations.py
+++ b/services/api/schemas/annotations.py
@@ -19,7 +19,7 @@ class AnnotationIn(ConfiguredModel):
 
 
 class TimePoint(AnnotationIn):
-    time: int
+    time: float
 
 
 class TimeRegion(AnnotationIn):

--- a/services/api/schemas/annotations.py
+++ b/services/api/schemas/annotations.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional
+from typing import Tuple, Optional, Union
 from services.api.schemas import ConfiguredModel
 from pydantic import Field, model_validator
 
@@ -43,5 +43,8 @@ class Annotation(AnnotationIn):
     sample_id: str
 
 
-class ModelAnnotation(Annotation):
+class ModelAnnotation(AnnotationIn):
     uncertainty: float
+
+
+AnnotationTypes = Union[TimePoint, TimeRegion, BoundingBox, VideoBoundingBox]

--- a/services/api/schemas/annotators.py
+++ b/services/api/schemas/annotators.py
@@ -13,6 +13,7 @@ class Annotator(BaseModel):
 
 
 class FindPeaksParams(Annotator):
+    signal_name: str
     prominence: float
     distance: int
     time_min: Optional[float]

--- a/services/api/schemas/data.py
+++ b/services/api/schemas/data.py
@@ -22,7 +22,7 @@ class CompositeData(Data):
 class SpectrogramData(Data):
     time: list[float]
     frequency: list[float]
-    values: list[list[float]]
+    amplitude: list[list[float]]
 
 
 class ImageData(Data):

--- a/services/api/schemas/data.py
+++ b/services/api/schemas/data.py
@@ -1,3 +1,4 @@
+from typing import Union
 from pydantic import BaseModel
 
 
@@ -14,11 +15,25 @@ class MultiVariateTimeSeriesData(Data):
     values: dict[str, TimeSeriesData]
 
 
+class CompositeData(Data):
+    values: dict[str, "DataResponseType"]
+
+
 class SpectrogramData(Data):
     time: list[float]
     frequency: list[float]
-    value: list[float]
+    values: list[list[float]]
 
 
 class ImageData(Data):
     data: list[list[tuple[int, int, int]]]
+
+
+DataResponseType = Union[
+    Data,
+    ImageData,
+    MultiVariateTimeSeriesData,
+    ImageData,
+    CompositeData,
+    SpectrogramData,
+]

--- a/services/api/schemas/projects.py
+++ b/services/api/schemas/projects.py
@@ -1,13 +1,12 @@
 from pydantic import Field
-from typing import Optional, List
 from enum import Enum
 from services.api.schemas import ConfiguredModel
-from services.api.schemas.samples import SampleIn
 
 
 class Task(Enum):
     ELM = "ELM"
     DISRUPTION = "disruption"
+    MHD = "MHD"
     UFO = "UFO"
 
 

--- a/services/api/schemas/samples.py
+++ b/services/api/schemas/samples.py
@@ -29,7 +29,7 @@ class FileData(ConfiguredModel):
 
 
 class TimeSeriesFileData(FileData):
-    column_names: Optional[list[str]]
+    column_names: Optional[list[str]] = None
 
 
 class ImageFileData(FileData):
@@ -44,7 +44,7 @@ class ShotData(ConfiguredModel):
 
 class SampleBase(ConfiguredModel):
     shot_id: int
-    data: FileData | ShotData
+    data: FileData | ShotData | TimeSeriesFileData
 
 
 class SampleIn(SampleBase):

--- a/services/api/schemas/views.py
+++ b/services/api/schemas/views.py
@@ -18,6 +18,8 @@ class SpectrogramViewParams(ViewParams):
     time_max: Optional[float] = None
     frequency_min: Optional[float] = None
     frequency_max: Optional[float] = None
+    amplitude_min: Optional[float] = None
+    amplitude_max: Optional[float] = None
 
 
 ViewParamTypes = Union[ViewParams, SpectrogramViewParams]

--- a/services/api/schemas/views.py
+++ b/services/api/schemas/views.py
@@ -1,0 +1,23 @@
+from enum import Enum
+from typing import Optional, Union
+from services.api.schemas import ConfiguredModel
+
+
+class ViewType(str, Enum):
+    IDENTITY = "identity"
+    SPECTROGRAM = "spectrogram"
+
+
+class ViewParams(ConfiguredModel):
+    name: ViewType = ViewType.IDENTITY
+
+
+class SpectrogramViewParams(ViewParams):
+    nperseg: Optional[int] = 256
+    time_min: Optional[float] = None
+    time_max: Optional[float] = None
+    frequency_min: Optional[float] = None
+    frequency_max: Optional[float] = None
+
+
+ViewParamTypes = Union[ViewParams, SpectrogramViewParams]

--- a/services/ui/package-lock.json
+++ b/services/ui/package-lock.json
@@ -16,7 +16,8 @@
         "react": "^19.0.0",
         "react-contexify": "^6.0.0",
         "react-dom": "^19.0.0",
-        "@adobe/react-spectrum": "^3.14.0"
+        "@adobe/react-spectrum": "^3.14.0",
+        "zod": "^3.25.67"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -30,7 +31,8 @@
         "eslint-config-next": "15.1.7",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5"
+        "typescript": "^5",
+        "zod": "^3.25.67"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/services/ui/package.json
+++ b/services/ui/package.json
@@ -17,7 +17,8 @@
     "react": "^19.0.0",
     "react-contexify": "^6.0.0",
     "react-dom": "^19.0.0",
-    "@adobe/react-spectrum": "^3.14.0"
+    "@adobe/react-spectrum": "^3.14.0",
+    "zod": "^3.25.67"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/services/ui/src/app/components/peaks.tsx
+++ b/services/ui/src/app/components/peaks.tsx
@@ -2,29 +2,6 @@
 import {Provider, defaultTheme, Slider, Flex, Header, ToggleButton, RangeSlider} from '@adobe/react-spectrum'
 import { useEffect, useState } from 'react';
 
-export function TimeRangeSlider({ data, onChange }) {
-    const [timeMinDefault, setTimeMinDefault] = useState(null);
-    const [timeMaxDefault, setTimeMaxDefault] = useState(null);
-    const [timeRange, setTimeRange] = useState({start: 0, end: 100}); 
-
-    useEffect(() => {
-        if (data && (!timeMinDefault || !timeMinDefault)) {
-            const time = data.time;
-            const tmin = Math.min(...time);
-            const tmax = Math.max(...time)
-            setTimeMinDefault(tmin);
-            setTimeMaxDefault(tmax);
-            setTimeRange({start: tmin, end: tmax});
-        }
-    }, [data]);
-
-    return (
-        <div className='m-4'>
-            <RangeSlider label="Time Range" defaultValue={{ start: timeMinDefault, end: timeMaxDefault }} value={timeRange} onChange={setTimeRange} onChangeEnd={onChange} step={0.001} minValue={timeMinDefault} maxValue={timeMaxDefault}/>
-        </div>
-    );
-}
-
 export function FindPeaksTool({ project_id, sample_id, data, setAnnotations }) {
     const [prominence, setProminance] = useState(0.1);
     const [distance, setDistance] = useState(1);

--- a/services/ui/src/app/components/peaks.tsx
+++ b/services/ui/src/app/components/peaks.tsx
@@ -66,7 +66,7 @@ export function FindPeaksTool({ project_id, sample_id, data, setAnnotations }) {
                 <br/>
                 <Slider label="Prominence" minValue={0.01} maxValue={1} defaultValue={prominence} step={0.001} onChangeEnd={setProminance}/>
                 <Slider label="Distance" minValue={1} maxValue={1000} defaultValue={distance} onChangeEnd={setDistance}/>
-                <RangeSlider label="Time Range" defaultValue={{ start: timeMinDefault, end: timeMaxDefault }} value={timeRange} onChange={setTimeRange} step={0.001} minValue={timeMinDefault} maxValue={timeMaxDefault}/>
+                <RangeSlider label="Time Range" defaultValue={{ start: timeMinDefault, end: timeMaxDefault }} value={timeRange} onChangeEnd={setTimeRange} step={0.001} minValue={timeMinDefault} maxValue={timeMaxDefault}/>
                 <br />
                 <Button variant="primary" onPress={clearPeaks} >Clear Peaks</Button>
             </Flex>

--- a/services/ui/src/app/components/peaks.tsx
+++ b/services/ui/src/app/components/peaks.tsx
@@ -1,8 +1,31 @@
 "use client";
-import {Provider, defaultTheme, Button, ButtonGroup, Slider, Flex, Header, ToggleButton, RangeSlider} from '@adobe/react-spectrum'
+import {Provider, defaultTheme, Slider, Flex, Header, ToggleButton, RangeSlider} from '@adobe/react-spectrum'
 import { useEffect, useState } from 'react';
 
-export default function FindPeaksTool({ project_id, sample_id, data, setAnnotations }) {
+export function TimeRangeSlider({ data, onChange }) {
+    const [timeMinDefault, setTimeMinDefault] = useState(null);
+    const [timeMaxDefault, setTimeMaxDefault] = useState(null);
+    const [timeRange, setTimeRange] = useState({start: 0, end: 100}); 
+
+    useEffect(() => {
+        if (data && (!timeMinDefault || !timeMinDefault)) {
+            const time = data.time;
+            const tmin = Math.min(...time);
+            const tmax = Math.max(...time)
+            setTimeMinDefault(tmin);
+            setTimeMaxDefault(tmax);
+            setTimeRange({start: tmin, end: tmax});
+        }
+    }, [data]);
+
+    return (
+        <div className='m-4'>
+            <RangeSlider label="Time Range" defaultValue={{ start: timeMinDefault, end: timeMaxDefault }} value={timeRange} onChange={setTimeRange} onChangeEnd={onChange} step={0.001} minValue={timeMinDefault} maxValue={timeMaxDefault}/>
+        </div>
+    );
+}
+
+export function FindPeaksTool({ project_id, sample_id, data, setAnnotations }) {
     const [prominence, setProminance] = useState(0.1);
     const [distance, setDistance] = useState(1);
     const [clearPeaks, setClearPeaks] = useState(false);
@@ -10,6 +33,7 @@ export default function FindPeaksTool({ project_id, sample_id, data, setAnnotati
     const [timeMinDefault, setTimeMinDefault] = useState(null);
     const [timeMaxDefault, setTimeMaxDefault] = useState(null);
     const [timeRange, setTimeRange] = useState({start: 0, end: 100}); 
+
 
     useEffect(() => {
         if (data) {
@@ -24,8 +48,8 @@ export default function FindPeaksTool({ project_id, sample_id, data, setAnnotati
     useEffect(() => {
         const fetchData = async () => {
             if (clearPeaks) {
-            setAnnotations([]);
-            return;
+                setAnnotations([]);
+                return;
             }
 
             const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/backend-api/projects/${project_id}/models/abc/predict/${sample_id}`, {

--- a/services/ui/src/app/components/peaks.tsx
+++ b/services/ui/src/app/components/peaks.tsx
@@ -1,5 +1,5 @@
 "use client";
-import {Provider, defaultTheme, Slider, Flex, Header, ToggleButton, RangeSlider} from '@adobe/react-spectrum'
+import {Provider, defaultTheme, Slider, Flex, Header, ComboBox, Item, ToggleButton, RangeSlider} from '@adobe/react-spectrum'
 import { useEffect, useState } from 'react';
 
 export function FindPeaksTool({ project_id, sample_id, data, setAnnotations }) {
@@ -10,11 +10,12 @@ export function FindPeaksTool({ project_id, sample_id, data, setAnnotations }) {
     const [timeMinDefault, setTimeMinDefault] = useState(null);
     const [timeMaxDefault, setTimeMaxDefault] = useState(null);
     const [timeRange, setTimeRange] = useState({start: 0, end: 100}); 
+    const [signalName, setSignalName] = useState('dalpha');
 
 
     useEffect(() => {
         if (data) {
-            const time = data.values['ip'].time;
+            const time = data.values[signalName].time;
             const tmin = Math.min(...time);
             const tmax = Math.max(...time)
             setTimeMinDefault(tmin);
@@ -35,6 +36,7 @@ export function FindPeaksTool({ project_id, sample_id, data, setAnnotations }) {
                 'Content-Type': 'application/json',
                 },
                 body: JSON.stringify({ 
+                    signal_name: signalName,
                     prominence: prominence,
                     distance: distance,
                     time_min: timeRange.start,
@@ -50,11 +52,17 @@ export function FindPeaksTool({ project_id, sample_id, data, setAnnotations }) {
     }, [prominence, distance, clearPeaks, timeRange]);
 
 
+    const signalOptions = Object.keys(data.values).map((value, index)=> ({id: index, name: value}));
+
     return (
         <Provider theme={defaultTheme}>
             <Header>Find Peaks</Header>
             <div className='m-4'>
             <Flex direction="column">
+                <ComboBox defaultItems={signalOptions} defaultInputValue={'dalpha'} onInputChange={setSignalName}>
+                    {x => <Item>{x.name}</Item>}
+                </ComboBox>
+                <br/>
                 <Slider label="Prominence" minValue={0.01} maxValue={1} defaultValue={prominence} step={0.001} onChangeEnd={setProminance}/>
                 <Slider label="Distance" minValue={1} maxValue={1000} defaultValue={distance} onChangeEnd={setDistance}/>
                 <RangeSlider label="Time Range" defaultValue={{ start: timeMinDefault, end: timeMaxDefault }} value={timeRange} onChange={setTimeRange} step={0.001} minValue={timeMinDefault} maxValue={timeMaxDefault}/>

--- a/services/ui/src/app/components/peaks.tsx
+++ b/services/ui/src/app/components/peaks.tsx
@@ -10,23 +10,28 @@ export function FindPeaksTool({ project_id, sample_id, data, setAnnotations }) {
     const [timeMinDefault, setTimeMinDefault] = useState(null);
     const [timeMaxDefault, setTimeMaxDefault] = useState(null);
     const [timeRange, setTimeRange] = useState({start: 0, end: 100}); 
-    const [signalName, setSignalName] = useState('dalpha');
+    const [signalName, setSignalName] = useState(null);
+    const signalOptions = Object.keys(data.values).map((value, index)=> ({id: index, name: value}));
 
 
     useEffect(() => {
-        if (data) {
+        if (data && (signalName in data.values)) {
             const time = data.values[signalName].time;
             const tmin = Math.min(...time);
             const tmax = Math.max(...time)
             setTimeMinDefault(tmin);
             setTimeMaxDefault(tmax);
         }
-    }, [data]);
+    }, [data, signalName]);
 
     useEffect(() => {
         const fetchData = async () => {
             if (clearPeaks) {
                 setAnnotations([]);
+                return;
+            }
+
+            if (signalName == null && !(signalName in data.values)) {
                 return;
             }
 
@@ -49,17 +54,16 @@ export function FindPeaksTool({ project_id, sample_id, data, setAnnotations }) {
         };
 
         fetchData();
-    }, [prominence, distance, clearPeaks, timeRange]);
+    }, [prominence, distance, clearPeaks, timeRange, signalName]);
 
 
-    const signalOptions = Object.keys(data.values).map((value, index)=> ({id: index, name: value}));
 
     return (
         <Provider theme={defaultTheme}>
             <Header>Find Peaks</Header>
             <div className='m-4'>
             <Flex direction="column">
-                <ComboBox defaultItems={signalOptions} defaultInputValue={'dalpha'} onInputChange={setSignalName}>
+                <ComboBox defaultItems={signalOptions} onInputChange={setSignalName} allowsEmptyCollection={true} placeholder="None selected">
                     {x => <Item>{x.name}</Item>}
                 </ComboBox>
                 <br/>

--- a/services/ui/src/app/components/peaks.tsx
+++ b/services/ui/src/app/components/peaks.tsx
@@ -1,11 +1,10 @@
 "use client";
-import {Provider, defaultTheme, Slider, Flex, Header, ComboBox, Item, ToggleButton, RangeSlider} from '@adobe/react-spectrum'
+import {Provider, defaultTheme, Slider, Button, Flex, Header, ComboBox, Item, ToggleButton, RangeSlider} from '@adobe/react-spectrum'
 import { useEffect, useState } from 'react';
 
 export function FindPeaksTool({ project_id, sample_id, data, setAnnotations }) {
     const [prominence, setProminance] = useState(0.1);
     const [distance, setDistance] = useState(1);
-    const [clearPeaks, setClearPeaks] = useState(false);
 
     const [timeMinDefault, setTimeMinDefault] = useState(null);
     const [timeMaxDefault, setTimeMaxDefault] = useState(null);
@@ -13,6 +12,9 @@ export function FindPeaksTool({ project_id, sample_id, data, setAnnotations }) {
     const [signalName, setSignalName] = useState(null);
     const signalOptions = Object.keys(data.values).map((value, index)=> ({id: index, name: value}));
 
+    const clearPeaks = () => {
+        setAnnotations([]);
+    };
 
     useEffect(() => {
         if (data && (signalName in data.values)) {
@@ -26,11 +28,6 @@ export function FindPeaksTool({ project_id, sample_id, data, setAnnotations }) {
 
     useEffect(() => {
         const fetchData = async () => {
-            if (clearPeaks) {
-                setAnnotations([]);
-                return;
-            }
-
             if (signalName == null && !(signalName in data.values)) {
                 return;
             }
@@ -54,7 +51,7 @@ export function FindPeaksTool({ project_id, sample_id, data, setAnnotations }) {
         };
 
         fetchData();
-    }, [prominence, distance, clearPeaks, timeRange, signalName]);
+    }, [prominence, distance, timeRange, signalName]);
 
 
 
@@ -70,7 +67,8 @@ export function FindPeaksTool({ project_id, sample_id, data, setAnnotations }) {
                 <Slider label="Prominence" minValue={0.01} maxValue={1} defaultValue={prominence} step={0.001} onChangeEnd={setProminance}/>
                 <Slider label="Distance" minValue={1} maxValue={1000} defaultValue={distance} onChangeEnd={setDistance}/>
                 <RangeSlider label="Time Range" defaultValue={{ start: timeMinDefault, end: timeMaxDefault }} value={timeRange} onChange={setTimeRange} step={0.001} minValue={timeMinDefault} maxValue={timeMaxDefault}/>
-                <ToggleButton isSelected={clearPeaks} onChange={setClearPeaks}>Clear Peaks</ToggleButton>
+                <br />
+                <Button variant="primary" onPress={clearPeaks} >Clear Peaks</Button>
             </Flex>
             </div>
         </Provider>

--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -140,7 +140,7 @@ export const TimeSeries = ({
         const reload = async () => {
             const { react } = await import('plotly.js') // Annoyingly there seems to be an issue with plotly so dynamic import is needed
             const root = document.getElementById(plotId)
-            react(root, data, layout, config).then(renderZones);
+            react(root, data, layout, config);
         };
         reload();
     }, [plotId, data]);

--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -49,13 +49,62 @@ export const TimeSeries = ({
     const {show: showContextMenu} = useContextMenuProvider()
     const showContextMenuRef = useRef(showContextMenu)
 
-    const dataRef = useRef(data)
-    const layoutRef = useRef(layout)
-    const configRef = useRef(config)
+    const overplots: string[] = [];
 
     const triggerToolUpdate = () => {
         setUpdateTools((current) => (current + 1) % 100)
     }
+
+    const renderZones = (plot: Plotly.PlotlyHTMLElement) =>  {
+        // Get all subplot elements and extract the subplot name (xy for example) from the class list
+        const subplots = plot.querySelectorAll(".subplot")
+        const subplotNames = [...subplots].map(el => 
+            [...el.classList].find(cls => cls !== "subplot")
+        )
+
+        // For each subplot identified generate a D3 overplot with the subplot name appended so that tooling can reference it
+        subplotNames.forEach(coordinateSystem => {
+            const subplot = plot.querySelector(`.subplot.${coordinateSystem}`)?.querySelector(".overplot")?.querySelector(`.${coordinateSystem}`) as HTMLElement
+            if (!subplot) {
+                console.error("Cannot locate disruption plotly subplot")
+                return
+            }
+
+            if (!subplot.querySelector(`.${plotId}-overplot-${coordinateSystem}`)) { // ensure only one custom overlay group is present
+                const svg = document.createElementNS("http://www.w3.org/2000/svg", "g")
+                svg.setAttribute("class", `${plotId}-overplot-${coordinateSystem}`)
+                svg.setAttribute("fill", "none");
+                subplot.appendChild(svg)
+                overplots.push(`${plotId}-overplot-${coordinateSystem}`) // Store overplots for removal
+            }
+        });
+        
+        setPlotReady(true)
+
+        const relayoutHandler = () => { // triggers re-render of overlay tools when axes change
+            triggerToolUpdate()
+        } 
+        plot.on("plotly_relayout", relayoutHandler) // attach listener so it can be removed
+
+        document.addEventListener("keydown", (e) => {
+            if (e.key === "Shift") {
+                const elements = plot.querySelectorAll(".disable-on-shift")
+                elements.forEach((element) => {
+                    element.setAttribute("style", "pointer-events: none")
+                })
+            }
+        })
+
+        document.addEventListener("keyup", (e) => {
+            if (e.key === "Shift") {
+                const elements = plot.querySelectorAll(".disable-on-shift")
+                elements.forEach((element) => {
+                    element.setAttribute("style", "pointer-events: all")
+                })
+            }
+        })
+    };
+
 
     // Main plotly rendering
     useEffect(() => {
@@ -68,65 +117,11 @@ export const TimeSeries = ({
 
         let plotElement: Plotly.PlotlyHTMLElement | null = null // holds the created plot for later cleanup
 
-        const overplots: string[] = [];
-
         const initGraph = async () => {
             const { react } = await import('plotly.js') // Annoyingly there seems to be an issue with plotly so dynamic import is needed
-
-            react(root, dataRef.current, layoutRef.current, configRef.current).then((plot: Plotly.PlotlyHTMLElement) => {
-                plotElement = plot // save reference to remove listeners later
-
-                // Get all subplot elements and extract the subplot name (xy for example) from the class list
-                const subplots = plot.querySelectorAll(".subplot")
-                const subplotNames = [...subplots].map(el => 
-                    [...el.classList].find(cls => cls !== "subplot")
-                )
-
-                // For each subplot identified generate a D3 overplot with the subplot name appended so that tooling can reference it
-                subplotNames.forEach(coordinateSystem => {
-                    const subplot = plot.querySelector(`.subplot.${coordinateSystem}`)?.querySelector(".overplot")?.querySelector(`.${coordinateSystem}`) as HTMLElement
-                    if (!subplot) {
-                        console.error("Cannot locate disruption plotly subplot")
-                        return
-                    }
-
-                    if (!subplot.querySelector(`.${plotId}-overplot-${coordinateSystem}`)) { // ensure only one custom overlay group is present
-                        const svg = document.createElementNS("http://www.w3.org/2000/svg", "g")
-                        svg.setAttribute("class", `${plotId}-overplot-${coordinateSystem}`)
-                        svg.setAttribute("fill", "none");
-                        subplot.appendChild(svg)
-                        overplots.push(`${plotId}-overplot-${coordinateSystem}`) // Store overplots for removal
-                    }
-                });
-                
-                setPlotReady(true)
-
-                const relayoutHandler = () => { // triggers re-render of overlay tools when axes change
-                    triggerToolUpdate()
-                } 
-                plot.on("plotly_relayout", relayoutHandler) // attach listener so it can be removed
-
-                document.addEventListener("keydown", (e) => {
-                    if (e.key === "Shift") {
-                        const elements = plot.querySelectorAll(".disable-on-shift")
-                        elements.forEach((element) => {
-                            element.setAttribute("style", "pointer-events: none")
-                        })
-                    }
-                })
-
-                document.addEventListener("keyup", (e) => {
-                    if (e.key === "Shift") {
-                        const elements = plot.querySelectorAll(".disable-on-shift")
-                        elements.forEach((element) => {
-                            element.setAttribute("style", "pointer-events: all")
-                        })
-                    }
-                })
-            })
+            react(root, data, layout, config).then(renderZones);
         }
         initGraph()
-        
         return () => { // cleanup on unmount / Fast-Refresh
             plotElement?.removeAllListeners?.("plotly_relayout"); // detach relayout listener
 
@@ -140,6 +135,15 @@ export const TimeSeries = ({
             setPlotReady(false); // reset ready state
         } 
     }, [plotId])
+
+    useEffect(() => {
+        const reload = async () => {
+            const { react } = await import('plotly.js') // Annoyingly there seems to be an issue with plotly so dynamic import is needed
+            const root = document.getElementById(plotId)
+            react(root, data, layout, config).then(renderZones);
+        };
+        reload();
+    }, [plotId, data]);
 
     // Handles context menu creation
     useEffect(() => {

--- a/services/ui/src/app/components/providers/vpsan-provider.tsx
+++ b/services/ui/src/app/components/providers/vpsan-provider.tsx
@@ -8,6 +8,7 @@ import { useContextMenuProvider } from "./context-menu-provider";
 interface VSpanContextInfo {
     vspans: VSpan[];
     handleVSpanUpdate: () => void;
+    handleVSpanDragFinish: () => void;
     addVSpan: (x: number, category: Category) => void;
     triggerUpdate: number;
 }
@@ -30,10 +31,11 @@ export const VSPAN_MENU_ID = "vspan-provider"
  * @param categories Array of categories that the vspans provided by this context can be
  * @param initialData Array of vspans that should be added when initialised
  */
-export const VSpanProvider = ({categories, initialData, children} : {
+export const VSpanProvider = ({categories, initialData, children, onModifyVSpan} : {
     categories: Category[],
     initialData?: VSpan[],
-    children: React.ReactNode
+    children: React.ReactNode,
+    onModifyVSpan: CallableFunction
 }) => {
     const spans = useRef<VSpan[]>([])
     const [triggerUpdate, setTriggerUpdate] = useState(0) // Value should be changed to trigger refresh
@@ -50,17 +52,25 @@ export const VSpanProvider = ({categories, initialData, children} : {
         triggerVSpanUpdate()
     }
 
+    // Provides a method for child components to update on drag finish
+    const handleVSpanDragFinish = () => {
+        onModifyVSpan(spans.current);
+    }
+
+
     const addVSpan = (x: number, category: Category) => {
         spans.current.push({
             category,
             x
         })
         triggerVSpanUpdate()
+        onModifyVSpan(spans.current);
     }
 
     const handleDelete = (input: unknown) => {
         spans.current = spans.current.filter(span => span !== input)
         triggerVSpanUpdate()
+        onModifyVSpan(spans.current);
     }
 
     const handleTypeSetting = ({props}: ItemParams, targetCategory: Category) => {
@@ -81,6 +91,7 @@ export const VSpanProvider = ({categories, initialData, children} : {
                 x
             })
             triggerVSpanUpdate()
+            onModifyVSpan(spans.current);
         }
 
         const addVSpanItems = categories.map((category, index) => {
@@ -124,7 +135,7 @@ export const VSpanProvider = ({categories, initialData, children} : {
 
     // The context provider is responsible for rendering the context menu relating to VSpans
     return (
-        <VSpanContext.Provider value={{vspans: spans.current, handleVSpanUpdate, addVSpan, triggerUpdate}}>
+        <VSpanContext.Provider value={{vspans: spans.current, handleVSpanUpdate, handleVSpanDragFinish, addVSpan, triggerUpdate}}>
             {children}
             <Menu id={`${VSPAN_MENU_ID}`}>
                 <Item id="delete" onClick={({props}: ItemParams) => {

--- a/services/ui/src/app/components/providers/zone-provider.tsx
+++ b/services/ui/src/app/components/providers/zone-provider.tsx
@@ -90,7 +90,9 @@ export const ZoneProvider = ({categories, initialData, children, onAddZone} : {
                 }
             )
             triggerZoneUpdate()
-            onAddZone(zones.current);
+            if (onAddZone) {
+                onAddZone(zones.current);
+            }
         }
     
             const addZoneItems = categories.map((category, index) => {

--- a/services/ui/src/app/components/providers/zone-provider.tsx
+++ b/services/ui/src/app/components/providers/zone-provider.tsx
@@ -97,6 +97,7 @@ export const ZoneProvider = ({categories, initialData, children, onModifyZone} :
                 }
             )
             triggerZoneUpdate();
+            onModifyZone(zones.current);
         }
     
             const addZoneItems = categories.map((category, index) => {

--- a/services/ui/src/app/components/providers/zone-provider.tsx
+++ b/services/ui/src/app/components/providers/zone-provider.tsx
@@ -32,7 +32,7 @@ export const ZONE_MENU_ID = "zone-provider"
  * @param categories Array of categories that the zones provided by this context can be
  * @param initialData Array of zones that should be added when initialised
  */
-export const ZoneProvider = ({categories, initialData, children, onAddZone} : {
+export const ZoneProvider = ({categories, initialData, children, onModifyZone} : {
     categories: Category[],
     initialData?: Zone[],
     children: React.ReactNode,
@@ -55,7 +55,7 @@ export const ZoneProvider = ({categories, initialData, children, onAddZone} : {
     }
 
     const handleZoneDragFinish = () => {
-        onAddZone(zones.current);
+        onModifyZone(zones.current);
     }
 
     const addZone = (x0: number, x1: number, category: Category) => {
@@ -67,12 +67,13 @@ export const ZoneProvider = ({categories, initialData, children, onAddZone} : {
             }
         )
         triggerZoneUpdate();
-        onAddZone(zones.current);
+        onModifyZone(zones.current);
     }
 
     const handleDelete = (input: unknown) => {
         zones.current = zones.current.filter(zone => zone !== input)
         triggerZoneUpdate()
+        onModifyZone(zones.current);
     }
 
     const handleTypeSetting = ({props}: ItemParams, targetCategory: Category) => {

--- a/services/ui/src/app/components/providers/zone-provider.tsx
+++ b/services/ui/src/app/components/providers/zone-provider.tsx
@@ -9,6 +9,7 @@ import { useContextMenuProvider } from "./context-menu-provider";
 interface ZoneContextInfo {
     zones: Zone[];
     handleZoneUpdate: () => void;
+    handleZoneDragFinish: () => void;
     addZone: (x0: number, x1: number, category: Category) => void;
     triggerUpdate: number;
 }
@@ -53,6 +54,10 @@ export const ZoneProvider = ({categories, initialData, children, onAddZone} : {
         triggerZoneUpdate()
     }
 
+    const handleZoneDragFinish = () => {
+        onAddZone(zones.current);
+    }
+
     const addZone = (x0: number, x1: number, category: Category) => {
         zones.current.push(
             {
@@ -61,7 +66,8 @@ export const ZoneProvider = ({categories, initialData, children, onAddZone} : {
                 x1
             }
         )
-        triggerZoneUpdate()
+        triggerZoneUpdate();
+        onAddZone(zones.current);
     }
 
     const handleDelete = (input: unknown) => {
@@ -89,10 +95,7 @@ export const ZoneProvider = ({categories, initialData, children, onAddZone} : {
                     x1
                 }
             )
-            triggerZoneUpdate()
-            if (onAddZone) {
-                onAddZone(zones.current);
-            }
+            triggerZoneUpdate();
         }
     
             const addZoneItems = categories.map((category, index) => {
@@ -138,7 +141,7 @@ export const ZoneProvider = ({categories, initialData, children, onAddZone} : {
 
     // The context provider is responsible for rendering the context menu relating to zones
     return(
-        <ZoneContext.Provider value={{zones: zones.current, handleZoneUpdate, addZone, triggerUpdate}}>
+        <ZoneContext.Provider value={{zones: zones.current, handleZoneUpdate, handleZoneDragFinish, addZone, triggerUpdate}}>
             {children}
             <Menu id={`${ZONE_MENU_ID}`}>
                 <Item id="delete" onClick={({props}: ItemParams) => {

--- a/services/ui/src/app/components/providers/zone-provider.tsx
+++ b/services/ui/src/app/components/providers/zone-provider.tsx
@@ -36,7 +36,7 @@ export const ZoneProvider = ({categories, initialData, children, onModifyZone} :
     categories: Category[],
     initialData?: Zone[],
     children: React.ReactNode,
-    onAddZone: CallableFunction
+    onModifyZone: CallableFunction
 }) => {
     const zones = useRef<Zone[]>([])
     const [triggerUpdate, setTriggerUpdate] = useState(0) // Value should be changed to trigger refresh

--- a/services/ui/src/app/components/tools/dataRangeSlider.tsx
+++ b/services/ui/src/app/components/tools/dataRangeSlider.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { RangeSlider} from '@adobe/react-spectrum'
+import { useEffect, useState } from 'react';
+
+export function DataRangeSlider({ name, data, onChange, getValueLabel}) {
+    const [timeMinDefault, setTimeMinDefault] = useState(null);
+    const [timeMaxDefault, setTimeMaxDefault] = useState(null);
+    const [timeRange, setTimeRange] = useState({start: 0, end: 100}); 
+
+    useEffect(() => {
+        if (data && (timeMinDefault === null || timeMinDefault === null)) {
+            const time = data;
+            let tmin = Math.min(...time);
+            let tmax = Math.max(...time); 
+            setTimeMinDefault(tmin);
+            setTimeMaxDefault(tmax);
+            setTimeRange({start: tmin, end: tmax});
+        }
+    }, [data]);
+
+    return (
+        <div className='m-4'>
+            <RangeSlider label={name} defaultValue={{ start: timeMinDefault, end: timeMaxDefault }} value={timeRange} onChange={setTimeRange} onChangeEnd={onChange} step={0.001} 
+            minValue={timeMinDefault} maxValue={timeMaxDefault} getValueLabel={getValueLabel}/>
+        </div>
+    );
+}

--- a/services/ui/src/app/components/tools/vspans.tsx
+++ b/services/ui/src/app/components/tools/vspans.tsx
@@ -20,7 +20,7 @@ export const VSpans = ({plotId, plotReady, forceUpdate} : ToolingProps) => {
     })
 
     // Hook to pull in data from context provider
-    const {vspans, handleVSpanUpdate, triggerUpdate} = useVSpanContext()
+    const {vspans, handleVSpanUpdate, handleVSpanDragFinish, triggerUpdate} = useVSpanContext()
 
     // Main rendering effect
     useEffect(() => {
@@ -88,6 +88,8 @@ export const VSpans = ({plotId, plotReady, forceUpdate} : ToolingProps) => {
                     const x = xaxis.p2d(newX); // The context provider stores the decimal value rather than pixel
                     d.x = x;
                     handleVSpanUpdate() // Global refresh must be triggered to update all linked plots
+                }).on("end", function(event, d) {
+                    handleVSpanDragFinish();  
                 })
 
             function handleContextMenu(event, vspan: VSpan) {

--- a/services/ui/src/app/components/tools/zones.tsx
+++ b/services/ui/src/app/components/tools/zones.tsx
@@ -24,7 +24,7 @@ export const Zones = ({
     })
 
     // Hook to pull in data from context provider
-    const {zones, handleZoneUpdate, triggerUpdate} = useZoneContext()
+    const {zones, handleZoneUpdate, handleZoneDragFinish, triggerUpdate} = useZoneContext()
 
     // Main rendering effect
     useEffect(() => {
@@ -111,6 +111,8 @@ export const Zones = ({
                     d.x0 = x0;
                     d.x1 = x1;
                     handleZoneUpdate()
+                }).on("end", function(event, d) {
+                    handleZoneDragFinish();  
                 })
 
             function handleContextMenu(event, zone: Zone) {

--- a/services/ui/src/app/components/tools/zones.tsx
+++ b/services/ui/src/app/components/tools/zones.tsx
@@ -133,7 +133,7 @@ export const Zones = ({
                     .attr("width", x1 - x0)
                     .attr("height", height)
                     .attr("fill", zone.category.color)
-                    .attr("opacity", 0.3)
+                    .attr("opacity", 0.5)
                     .attr("style", "pointer-events: all")
                     .style("cursor", "move")
                     .datum(zone)

--- a/services/ui/src/app/core.tsx
+++ b/services/ui/src/app/core.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from 'react';
 
+
 export const getURL = (url: string) => {
   const [data, setData] = useState<any>(null);
 
@@ -81,12 +82,18 @@ export const getProject = (project_id: string) => {
   return project;
 } 
 
-export const getSampleData = (project_id: string, sample_id: string) => {
+export const getSampleData = (project_id: string, sample_id: string, viewParams) => {
   const [sampleData, setSampleData] = useState<any>(null);
 
   useEffect(() => {
     const fetchData = async () => {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/backend-api/projects/${project_id}/samples/${sample_id}/data`);
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/backend-api/projects/${project_id}/samples/${sample_id}/data`, {
+        method: 'POST',
+        headers: {
+        'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(viewParams),
+      });
       const data = await response.json();
       setSampleData(data);
     };

--- a/services/ui/src/app/disruption/components/disruption.tsx
+++ b/services/ui/src/app/disruption/components/disruption.tsx
@@ -107,7 +107,6 @@ export const Disruption = ({ data, annotations, setAnnotations}: {data: Disrupti
         }));
 
 
-        console.log(spans);
         const otherAnnotations = annotations.filter(x => !TimePoint.safeParse(x).success);
         spans = spans.concat(otherAnnotations);
         setAnnotations(spans);

--- a/services/ui/src/app/disruption/components/disruption.tsx
+++ b/services/ui/src/app/disruption/components/disruption.tsx
@@ -25,7 +25,11 @@ export const Disruption = ({ data, annotations, setAnnotations}: {data: Disrupti
             { name: "Disruption", color: 'rgb(255, 0, 0)' },
         ]
 
-    const zones = annotations.map(item => ({x0: item.time_min, x1: item.time_max, category: zoneCategories[0]}));
+    const convertRegionToZone = (item) => {
+        const category = zoneCategories.find(x => x.name === item.label);
+        return {x0: item.time_min, x1: item.time_max, category: category};
+    };
+    const zones = annotations.map(convertRegionToZone);
 
     const plotData: Plotly.Data[] = [
         {

--- a/services/ui/src/app/disruption/components/disruption.tsx
+++ b/services/ui/src/app/disruption/components/disruption.tsx
@@ -14,25 +14,18 @@ type DisruptionInfo = {
     values: Record<string, Array<number>>
 }
 
-export const Disruption = ({ data }: DisruptionInfo) => {
+export const Disruption = ({ data, annotations, setAnnotations}: {data: DisruptionInfo}) => {
     const zoneCategories: Category[] = [
             { name: "RampUp", color: 'rgb(233, 170, 98)' },
             { name: "FlatTop", color: 'rgb(120, 167, 85)' },
             { name: "RampDown", color: 'rgb(108, 189, 224)' }
         ]
 
-    const initialZones: Zone[] = [
-        { x0: 0.05, x1: 0.1, category: zoneCategories[0] },
-        { x0: 0.15, x1: 0.2, category: zoneCategories[1] },
-    ]
-
     const disruptionCategories: Category[] = [
             { name: "Disruption", color: 'rgb(255, 0, 0)' },
         ]
 
-    const initialDisruption: VSpan[] = [
-        { x: 0.3, category: disruptionCategories[0] }
-    ]
+    const zones = annotations.map(item => ({x0: item.time_min, x1: item.time_max, category: zoneCategories[0]}));
 
     const plotData: Plotly.Data[] = [
         {
@@ -83,11 +76,22 @@ export const Disruption = ({ data }: DisruptionInfo) => {
         dragmode: 'pan',
     };
 
+    const updateAnnotations = (newZones) => {
+
+        const zones = newZones.map(item => ({
+                time_min: item.x0,
+                time_max: item.x1,
+                label: item.category.name
+        }));
+
+        setAnnotations(zones);
+    }
+
     return (
         <div className="flex flex-col items-center space-y-3">
             <ContextMenuProvider menuId="disruption-menu">
-                <VSpanProvider categories={disruptionCategories} initialData={initialDisruption}>
-                    <ZoneProvider categories={zoneCategories} initialData={initialZones}>
+                <VSpanProvider categories={disruptionCategories} initialData={[]}>
+                    <ZoneProvider categories={zoneCategories} initialData={zones} onModifyZone={updateAnnotations}>
                         <TimeSeries plotId="Disruption" plotConfig={{data: plotData, layout: plotLayout}}>
                             <Zones />
                             <VSpans />

--- a/services/ui/src/app/disruption/components/disruption.tsx
+++ b/services/ui/src/app/disruption/components/disruption.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Category, VSpan, Zone } from "@/types"
+import { Category, VSpan, Zone, TimeRegion, TimePoint } from "@/types"
 import { ZoneProvider } from "@/app/components/providers/zone-provider"
 import { VSpanProvider } from "@/app/components/providers/vpsan-provider"
 import { DisruptionTable } from "./disruption-table"
@@ -9,27 +9,34 @@ import { TimeSeries } from "@/app/components/plots/time-series"
 import { Zones } from "@/app/components/tools/zones"
 import { VSpans } from "@/app/components/tools/vspans"
 
+
 type DisruptionInfo = {
     time: Array<number>,
     values: Record<string, Array<number>>
 }
 
 export const Disruption = ({ data, annotations, setAnnotations}: {data: DisruptionInfo}) => {
+    const disruptionCategories: Category[] = [
+            { name: "Disruption", color: 'rgb(255, 0, 0)' },
+        ]
+
+    const convertTimePointToVSpan = (item) => {
+        const category = disruptionCategories.find(x => x.name === item.label);
+        return {x: item.time, category: category};
+    };
+    const spans = annotations.filter(x => TimePoint.safeParse(x).success).map(convertTimePointToVSpan);
+
     const zoneCategories: Category[] = [
             { name: "RampUp", color: 'rgb(233, 170, 98)' },
             { name: "FlatTop", color: 'rgb(120, 167, 85)' },
             { name: "RampDown", color: 'rgb(108, 189, 224)' }
         ]
 
-    const disruptionCategories: Category[] = [
-            { name: "Disruption", color: 'rgb(255, 0, 0)' },
-        ]
-
-    const convertRegionToZone = (item) => {
+    const convertTimeRegionToZone = (item) => {
         const category = zoneCategories.find(x => x.name === item.label);
         return {x0: item.time_min, x1: item.time_max, category: category};
     };
-    const zones = annotations.map(convertRegionToZone);
+    const zones = annotations.filter(x => TimeRegion.safeParse(x).success).map(convertTimeRegionToZone);
 
     const plotData: Plotly.Data[] = [
         {
@@ -80,22 +87,37 @@ export const Disruption = ({ data, annotations, setAnnotations}: {data: Disrupti
         dragmode: 'pan',
     };
 
-    const updateAnnotations = (newZones) => {
-
-        const zones = newZones.map(item => ({
+    const updateZones = (newZones) => {
+        let zones = newZones.map(item => ({
                 time_min: item.x0,
                 time_max: item.x1,
                 label: item.category.name
         }));
 
-        setAnnotations(zones);
-    }
 
+        const otherAnnotations = annotations.filter(x => !TimeRegion.safeParse(x).success);
+        zones = zones.concat(otherAnnotations);
+        setAnnotations(zones);
+    };
+
+    const updateVSpans = (newVSpans) =>  {
+        let spans = newVSpans.map(item => ({
+                time: item.x,
+                label: item.category.name
+        }));
+
+
+        console.log(spans);
+        const otherAnnotations = annotations.filter(x => !TimePoint.safeParse(x).success);
+        spans = spans.concat(otherAnnotations);
+        setAnnotations(spans);
+    };
+    
     return (
         <div className="flex flex-col items-center space-y-3">
             <ContextMenuProvider menuId="disruption-menu">
-                <VSpanProvider categories={disruptionCategories} initialData={[]}>
-                    <ZoneProvider categories={zoneCategories} initialData={zones} onModifyZone={updateAnnotations}>
+                <VSpanProvider categories={disruptionCategories} initialData={spans} onModifyVSpan={updateVSpans}>
+                    <ZoneProvider categories={zoneCategories} initialData={zones} onModifyZone={updateZones}>
                         <TimeSeries plotId="Disruption" plotConfig={{data: plotData, layout: plotLayout}}>
                             <Zones />
                             <VSpans />

--- a/services/ui/src/app/elm/components/elms.tsx
+++ b/services/ui/src/app/elm/components/elms.tsx
@@ -188,7 +188,7 @@ export const ElmGraph = ({data, annotations, setAnnotations}) => {
         <div className="flex space-y-3">
             <div className="flex-1 text-center items-center">
                 <ContextMenuProvider menuId="elm-menu">
-                    <ZoneProvider categories={zoneCategories} initialData={zones} onAddZone={updateAnnotations}>
+                    <ZoneProvider categories={zoneCategories} initialData={zones} onModifyZone={updateAnnotations}>
                         <TimeSeries plotId="ELMs" plotConfig={{data: plotData, layout: plotLayout}}>
                             <Zones />
                         </TimeSeries>

--- a/services/ui/src/app/elm/components/elms.tsx
+++ b/services/ui/src/app/elm/components/elms.tsx
@@ -5,6 +5,7 @@ import { TimeSeries } from "@/app/components/plots/time-series"
 import { Zones } from "@/app/components/tools/zones"
 import 'react-contexify/ReactContexify.css';
 import Plotly from "plotly.js-dist";
+import { DisruptionTable } from "@/app/disruption/components/disruption-table"
 
 export const ElmGraph = ({data, annotations, setAnnotations}) => {
 
@@ -180,7 +181,7 @@ export const ElmGraph = ({data, annotations, setAnnotations}) => {
                 label: item.category.name
         }));
 
-        setAnnotations(zones)
+        setAnnotations(zones);
     }
 
     return (

--- a/services/ui/src/app/elm/components/elms.tsx
+++ b/services/ui/src/app/elm/components/elms.tsx
@@ -169,10 +169,15 @@ export const ElmGraph = ({data, annotations, setAnnotations}) => {
 
     
     const zoneCategories: Category[] = [
-            { name: "ELM", color: 'rgb(233, 170, 98)' },
-        ]
+        { name: "ELM", color: 'rgb(233, 170, 98)' },
+        { name: "H-Mode", color: 'rgb(100, 170, 98)' },
+    ]
 
-    const zones = annotations.map(item => ({x0: item.time_min, x1: item.time_max, category: zoneCategories[0]}));
+    const convertRegionToZone = (item) => {
+        const category = zoneCategories.find(x => x.name === item.label);
+        return {x0: item.time_min, x1: item.time_max, category: category};
+    };
+    const zones = annotations.map(convertRegionToZone);
 
     const updateAnnotations = (newZones) => {
         const zones = newZones.map(item => ({

--- a/services/ui/src/app/locked-mode/components/locked-mode.tsx
+++ b/services/ui/src/app/locked-mode/components/locked-mode.tsx
@@ -58,7 +58,7 @@ export const LockedMode = ({ data, annotations, setAnnotations }: {data: LockedM
         coloraxis: 'coloraxis'
     }];
 
-    const interpFunc = d3.interpolatePlasma;
+    const interpFunc = d3.interpolateRdBu;
 
     const plotLayout: Partial<Plotly.Layout> = {
         height: 600,

--- a/services/ui/src/app/locked-mode/components/locked-mode.tsx
+++ b/services/ui/src/app/locked-mode/components/locked-mode.tsx
@@ -115,7 +115,7 @@ export const LockedMode = ({ data, annotations, setAnnotations }: {data: LockedM
         <div className="flex flex-col items-center space-y-3">
             <ContextMenuProvider menuId="locked-mode-menu">
                 <VSpanProvider categories={lockedModeCategories} initialData={initialLockedMode}>
-                    <ZoneProvider categories={zoneCategories} initialData={zones} onAddZone={updateAnnotations}>
+                    <ZoneProvider categories={zoneCategories} initialData={zones} onModifyZone={updateAnnotations}>
                         <TimeSeries plotId="LockedMode" plotConfig={{ data: plotData, config: plotConfig, layout: plotLayout }} >
                             <Zones />
                             <VSpans />

--- a/services/ui/src/app/locked-mode/components/locked-mode.tsx
+++ b/services/ui/src/app/locked-mode/components/locked-mode.tsx
@@ -29,28 +29,24 @@ export const LockedMode = ({ data }) => {
     const lockedModeCategories: Category[] = [
         { name: "Locked Mode", color: "rgb(255, 0, 0)" },
     ]
-    const initialLockedMode: VSpan[] = [
-        { x: 0.1, category: lockedModeCategories[0] },
-    ]
+    const initialLockedMode: VSpan[] = []
 
     const zoneCategories: Category[] = [
-        { name: "ZoneA", color: 'rgb(255, 0, 0)' },
+        { name: "NTM", color: 'rgb(0, 0, 255)' },
+        { name: "LLM", color: 'rgb(211, 0, 255)' },
     ]
-    const initialZones: Zone[] = [
-        { x0: 0.4, x1: 0.5, category: zoneCategories[0] },
-    ]
+    const initialZones: Zone[] = []
 
     const originalAmpMin = Math.min(...data.amplitude.flat());
     const originalAmpMax = Math.max(...data.amplitude.flat());
 
-    const logAmplitude = data.amplitude.map(row => row.map(x => Math.log10(x)));
+    const logAmplitude = data.amplitude.map(row => row.map(x => Math.log10(Math.max(x, 1e-4))));
     const logAmpMin = Math.min(...logAmplitude.flat());
     const logAmpMax = Math.max(...logAmplitude.flat());
 
     const tickvals = linspace(logAmpMin, logAmpMax, 10)
-    let ticktext = linspace(originalAmpMin, originalAmpMax, 10);
-    ticktext = ticktext.map(x => Math.round(x * 100) / 100);
-
+    let ticktext = tickvals.map(x => Math.pow(10, x));
+    ticktext = ticktext.map(x => Math.round(x * 10000) / 10000);
 
     const plotData: Plotly.Data[] = [{
         name: "Saddle Coil FFT",

--- a/services/ui/src/app/locked-mode/components/locked-mode.tsx
+++ b/services/ui/src/app/locked-mode/components/locked-mode.tsx
@@ -42,34 +42,29 @@ export const LockedMode = ({ data }: LockedModeInfo) => {
         { x0: 0.4, x1: 0.5, category: zoneCategories[0] },
     ]
 
-    const [range, setRange] = useState<number[]>([1E-4, 1E-3]);
+    const originalAmpMin = Math.min(...data.amplitude.flat());
+    const originalAmpMax = Math.max(...data.amplitude.flat());
 
-    const ampl = data.map(({ amplitude }) => amplitude);
-    const logvals = linspace(range[0], range[1], 10)
-    const logvalsMapped = logvals.map((x) => (9 / (Math.max(...logvals) - Math.min(...logvals))) * (x - Math.min(...logvals)) + 1.0)
-    const tickvals = logvalsMapped.map((x) => Math.log10(x))
-    let zdata: number[] = []
-    ampl.forEach((val) => {
-        const index = logvals.findIndex(i => i >= val)
-        const ratio = (val - logvals[index - 1]) / (logvals[index] - logvals[index - 1])
-        const valScaled = (tickvals[index] - tickvals[index - 1]) * ratio + tickvals[index - 1]
-        if (index === -1) {
-            zdata.push(1.0)
-        } else {
-            zdata.push(valScaled)
-        }
-    })
+    const logAmplitude = data.amplitude.map(row => row.map(x => Math.log10(x)));
+    const logAmpMin = Math.min(...logAmplitude.flat());
+    const logAmpMax = Math.max(...logAmplitude.flat());
+
+    const tickvals = linspace(logAmpMin, logAmpMax, 10)
+    let ticktext = linspace(originalAmpMin, originalAmpMax, 10);
+    ticktext = ticktext.map(x => Math.round(x * 100) / 100);
+
 
     const plotData: Plotly.Data[] = [{
         name: "Saddle Coil FFT",
         type: 'heatmap',
-        x: data.map(({ time }) => time),
-        y: data.map(({ frequency }) => frequency),
-        z: zdata,
-        customdata: ampl,
+        x: data.time,
+        y: data.frequency,
+        z: logAmplitude,
         hovertemplate: "t: %{x:.2f}s<br>f: %{y:.2f}Hz<br>s: %{customdata:.2e}<extra></extra>",
         coloraxis: 'coloraxis'
     }];
+
+    const interpFunc = d3.interpolateTurbo;
 
     const plotLayout: Partial<Plotly.Layout> = {
         xaxis: {
@@ -83,24 +78,24 @@ export const LockedMode = ({ data }: LockedModeInfo) => {
             },
         },
         coloraxis: {
-            cmin: 0,
-            cmax: 1,
+            cmin: logAmpMin,
+            cmax: logAmpMax,
             colorscale: [
-                [0, d3.interpolateCividis(0)],
-                [0.1, d3.interpolateCividis(0.1)],
-                [0.2, d3.interpolateCividis(0.2)],
-                [0.3, d3.interpolateCividis(0.3)],
-                [0.4, d3.interpolateCividis(0.4)],
-                [0.5, d3.interpolateCividis(0.5)],
-                [0.6, d3.interpolateCividis(0.6)],
-                [0.7, d3.interpolateCividis(0.7)],
-                [0.8, d3.interpolateCividis(0.8)],
-                [0.9, d3.interpolateCividis(0.9)],
-                [1, d3.interpolateCividis(1)]
+                [0, interpFunc(0)],
+                [0.1, interpFunc(0.1)],
+                [0.2, interpFunc(0.2)],
+                [0.3, interpFunc(0.3)],
+                [0.4, interpFunc(0.4)],
+                [0.5, interpFunc(0.5)],
+                [0.6, interpFunc(0.6)],
+                [0.7, interpFunc(0.7)],
+                [0.8, interpFunc(0.8)],
+                [0.9, interpFunc(0.9)],
+                [1, interpFunc(1)]
             ],
             colorbar: {
                 tickmode: 'array',
-                ticktext: logvals.map((x) => x.toExponential(1)),
+                ticktext: ticktext,
                 tickvals: tickvals,
             }
         },

--- a/services/ui/src/app/locked-mode/components/locked-mode.tsx
+++ b/services/ui/src/app/locked-mode/components/locked-mode.tsx
@@ -31,15 +31,19 @@ export const LockedMode = ({ data, annotations, setAnnotations }: {data: LockedM
     ]
     const initialLockedMode: VSpan[] = []
     const zoneCategories: Category[] = [
-        { name: "NTM", color: 'rgb(0, 0, 255)' },
+        { name: "NTM", color: 'rgb(0, 255, 255)' },
     ]
     const zones = annotations.map(item => ({x0: item.time_min, x1: item.time_max, category: zoneCategories[0]}));
 
-    const logAmplitude = data.amplitude.map(row => row.map(x => Math.log10(Math.max(x, 1e-4))));
+    const amplitude = data.amplitude;
+    const ampMin = Math.max(1e-4, Math.min(...amplitude.flat()));
+    const ampMax = Math.max(...amplitude.flat());
+    
+    const logAmplitude = amplitude.map(row => row.map(x => Math.log10(Math.max(x, 1e-4))));
     const logAmpMin = Math.min(...logAmplitude.flat());
     const logAmpMax = Math.max(...logAmplitude.flat());
 
-    const tickvals = linspace(logAmpMin, logAmpMax, 10)
+    const tickvals = linspace(ampMin, ampMax, 6).map(x => Math.log10(x));
     let ticktext = tickvals.map(x => Math.pow(10, x));
     ticktext = ticktext.map(x => Math.round(x * 10000) / 10000);
 
@@ -54,9 +58,10 @@ export const LockedMode = ({ data, annotations, setAnnotations }: {data: LockedM
         coloraxis: 'coloraxis'
     }];
 
-    const interpFunc = d3.interpolateTurbo;
+    const interpFunc = d3.interpolatePlasma;
 
     const plotLayout: Partial<Plotly.Layout> = {
+        height: 600,
         xaxis: {
             title: {
                 text: 'Time [s]'
@@ -87,6 +92,9 @@ export const LockedMode = ({ data, annotations, setAnnotations }: {data: LockedM
                 tickmode: 'array',
                 ticktext: ticktext,
                 tickvals: tickvals,
+                tickfont: {
+                    size: 10
+                }
             }
         },
         showlegend: true,

--- a/services/ui/src/app/locked-mode/components/locked-mode.tsx
+++ b/services/ui/src/app/locked-mode/components/locked-mode.tsx
@@ -24,21 +24,16 @@ type LockedModeInfo = {
     data: SpectrogramData
 }
 
-export const LockedMode = ({ data }) => {
+export const LockedMode = ({ data, annotations, setAnnotations }: {data: LockedModeInfo}) => {
 
     const lockedModeCategories: Category[] = [
         { name: "Locked Mode", color: "rgb(255, 0, 0)" },
     ]
     const initialLockedMode: VSpan[] = []
-
     const zoneCategories: Category[] = [
         { name: "NTM", color: 'rgb(0, 0, 255)' },
-        { name: "LLM", color: 'rgb(211, 0, 255)' },
     ]
-    const initialZones: Zone[] = []
-
-    const originalAmpMin = Math.min(...data.amplitude.flat());
-    const originalAmpMax = Math.max(...data.amplitude.flat());
+    const zones = annotations.map(item => ({x0: item.time_min, x1: item.time_max, category: zoneCategories[0]}));
 
     const logAmplitude = data.amplitude.map(row => row.map(x => Math.log10(Math.max(x, 1e-4))));
     const logAmpMin = Math.min(...logAmplitude.flat());
@@ -106,11 +101,21 @@ export const LockedMode = ({ data }) => {
         modeBarButtonsToRemove: ['pan'],
     }
 
+    const updateAnnotations = (newZones) => {
+        const zones = newZones.map(item => ({
+                time_min: item.x0,
+                time_max: item.x1,
+                label: item.category.name
+        }));
+
+        setAnnotations(zones);
+    }
+
     return (
         <div className="flex flex-col items-center space-y-3">
             <ContextMenuProvider menuId="locked-mode-menu">
                 <VSpanProvider categories={lockedModeCategories} initialData={initialLockedMode}>
-                    <ZoneProvider categories={zoneCategories} initialData={initialZones}>
+                    <ZoneProvider categories={zoneCategories} initialData={zones} onAddZone={updateAnnotations}>
                         <TimeSeries plotId="LockedMode" plotConfig={{ data: plotData, config: plotConfig, layout: plotLayout }} >
                             <Zones />
                             <VSpans />

--- a/services/ui/src/app/locked-mode/components/locked-mode.tsx
+++ b/services/ui/src/app/locked-mode/components/locked-mode.tsx
@@ -9,8 +9,6 @@ import { TimeSeries } from "@/app/components/plots/time-series"
 import { Zones } from "@/app/components/tools/zones"
 import { VSpans } from "@/app/components/tools/vspans"
 
-import { useState } from "react"
-
 import * as d3 from "d3"
 
 const linspace = (start: number, end: number, num: number) => {
@@ -26,7 +24,7 @@ type LockedModeInfo = {
     data: SpectrogramData
 }
 
-export const LockedMode = ({ data }: LockedModeInfo) => {
+export const LockedMode = ({ data }) => {
 
     const lockedModeCategories: Category[] = [
         { name: "Locked Mode", color: "rgb(255, 0, 0)" },
@@ -60,7 +58,8 @@ export const LockedMode = ({ data }: LockedModeInfo) => {
         x: data.time,
         y: data.frequency,
         z: logAmplitude,
-        hovertemplate: "t: %{x:.2f}s<br>f: %{y:.2f}Hz<br>s: %{customdata:.2e}<extra></extra>",
+        customdata: data.amplitude,
+        hovertemplate: "time: %{x:.2f}s<br>freq: %{y:.2f}Hz<br>amp: %{customdata:.2e}<extra></extra>",
         coloraxis: 'coloraxis'
     }];
 
@@ -108,20 +107,15 @@ export const LockedMode = ({ data }: LockedModeInfo) => {
         displaylogo: false,
         displayModeBar: true,
         scrollZoom: false,
-        modeBarButtonsToRemove: ['toImage', 'zoom2d', 'zoomIn2d', 'zoomOut2d', 'autoScale2d'],
+        modeBarButtonsToRemove: ['pan'],
     }
 
     return (
         <div className="flex flex-col items-center space-y-3">
-            <header className="p-6">
-                <h1 className="text-4xl font-bold text-center text-gray-900">
-                    Locked Mode demo
-                </h1>
-            </header>
             <ContextMenuProvider menuId="locked-mode-menu">
                 <VSpanProvider categories={lockedModeCategories} initialData={initialLockedMode}>
                     <ZoneProvider categories={zoneCategories} initialData={initialZones}>
-                        <TimeSeries plotId="LockedMode" plotConfig={{ data: plotData!, layout: plotLayout!, config: plotConfig }} >
+                        <TimeSeries plotId="LockedMode" plotConfig={{ data: plotData, config: plotConfig, layout: plotLayout }} >
                             <Zones />
                             <VSpans />
                         </TimeSeries>

--- a/services/ui/src/app/locked-mode/components/locked-mode.tsx
+++ b/services/ui/src/app/locked-mode/components/locked-mode.tsx
@@ -32,8 +32,14 @@ export const LockedMode = ({ data, annotations, setAnnotations }: {data: LockedM
     const initialLockedMode: VSpan[] = []
     const zoneCategories: Category[] = [
         { name: "NTM", color: 'rgb(0, 255, 255)' },
+        { name: "LLM", color: 'rgb(200, 100, 100)' },
     ]
-    const zones = annotations.map(item => ({x0: item.time_min, x1: item.time_max, category: zoneCategories[0]}));
+
+    const convertRegionToZone = (item) => {
+        const category = zoneCategories.find(x => x.name === item.label);
+        return {x0: item.time_min, x1: item.time_max, category: category};
+    };
+    const zones = annotations.map(convertRegionToZone);
 
     const amplitude = data.amplitude;
     const ampMin = Math.max(1e-4, Math.min(...amplitude.flat()));

--- a/services/ui/src/app/locked-mode/components/locked-mode.tsx
+++ b/services/ui/src/app/locked-mode/components/locked-mode.tsx
@@ -58,7 +58,7 @@ export const LockedMode = ({ data, annotations, setAnnotations }: {data: LockedM
         coloraxis: 'coloraxis'
     }];
 
-    const interpFunc = d3.interpolateRdBu;
+    const interpFunc = d3.interpolateCividis;
 
     const plotLayout: Partial<Plotly.Layout> = {
         height: 600,

--- a/services/ui/src/app/projects/[project_id]/samples/[sample_id]/page.tsx
+++ b/services/ui/src/app/projects/[project_id]/samples/[sample_id]/page.tsx
@@ -3,9 +3,10 @@ import {Provider, defaultTheme, Breadcrumbs, Item, Button, ButtonGroup, ToastCon
 import { Disruption } from '@/app/disruption/components/disruption';
 import { ElmGraph } from '@/app/elm/components/elms';
 import { getSample, getProject, getSampleData } from '@/app/core';
-import { use, useState, createContext, useContext } from 'react';
+import { use, useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import FindPeaksTool from '@/app/components/peaks';
+import { LockedMode } from '@/app/locked-mode/components/locked-mode';
 
 export const SampleDataBreadCrumbs = (info) => {
   return (
@@ -24,6 +25,8 @@ const SampleView = (args) => {
     return (<Disruption data={args.data}/>);
   } else if (args.project.task == 'ELM') {
     return (<ElmGraph data={args.data} annotations={args.annotations} setAnnotations={args.setAnnotations}/>);
+  } else if (args.project.task == 'MHD') {
+    return (<LockedMode data={args.data.values['mirnov']}/>);
   }
 }
 
@@ -109,21 +112,63 @@ function ToolBar({ project, sample_id, data, annotations, setAnnotations}) {
   );
 }
 
+export async function getData(url) {
+    const response = await fetch(url);
+    const payload = await response.json();
+    return payload;
+}
+
+async function getSample(project_id: string, sample_id: string) {
+    return await getData(`${process.env.NEXT_PUBLIC_API_URL}/backend-api/projects/${project_id}/samples/${sample_id}`);
+}
+
+async function getProject(project_id: string) {
+    return await getData(`${process.env.NEXT_PUBLIC_API_URL}/backend-api/projects/${project_id}`);
+}
+
+
+
 export default function SamplePage({ params }: Props) {
   const props = use(params);
   const project_id = props.project_id;
   const sample_id = props.sample_id;
 
-  const project = getProject(project_id);
-  const sample = getSample(project_id, sample_id);
-  const data = getSampleData(project_id, sample_id);
-  const [ annotations, setAnnotations ] = useState([]);
+  const [project, setProject] = useState<any>(null);
+  const [sample, setSample] = useState<any>(null);
+  const [data, setData] = useState<any>(null);
+  const [annotations, setAnnotations] = useState<any>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const project = await getProject(project_id);
+      setProject(project);
+
+      const sample = await getSample(project_id, sample_id)
+      setSample(sample);
+
+      let viewParams = null;
+      if (project.task == 'MHD') {
+        viewParams = {name: 'spectrogram', 'nperseg': 256, 'amplitude_min': 1e-4};
+      }
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/backend-api/projects/${project_id}/samples/${sample_id}/data`, {
+          method: 'POST',
+          headers: {
+          'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(viewParams),
+      });
+      const data = await response.json();
+      setData(data);
+    };
+
+    fetchData();
+  }, []);
 
   if (!data) {
     return;
   }
+  console.log(data);
 
-  console.log(annotations);
   return (
     <div>
       <Provider theme={defaultTheme}>

--- a/services/ui/src/app/projects/[project_id]/samples/[sample_id]/page.tsx
+++ b/services/ui/src/app/projects/[project_id]/samples/[sample_id]/page.tsx
@@ -25,9 +25,9 @@ const SampleView = (args) => {
   if (args.project.task == 'disruption') {
     return (<Disruption data={args.data}/>);
   } else if (args.project.task == 'ELM') {
-    return (<ElmGraph data={args.data} annotations={args.annotations} setAnnotations={args.setAnnotations}/>);
+    return (<ElmGraph data={args.data} annotations={args.annotations} setAnnotations={args.setAnnotations} />);
   } else if (args.project.task == 'MHD') {
-    return (<LockedMode data={args.data.values['mirnov']} viewParams={args.viewParams}/>);
+    return (<LockedMode data={args.data.values['mirnov']} viewParams={args.viewParams} annotations={args.annotations} setAnnotations={args.setAnnotations}/>);
   }
 }
 
@@ -168,6 +168,10 @@ async function getProject(project_id: string) {
     return await getData(`${process.env.NEXT_PUBLIC_API_URL}/backend-api/projects/${project_id}`);
 }
 
+async function getAnnotations(project_id: string, sample_id: string) {
+    return await getData(`${process.env.NEXT_PUBLIC_API_URL}/backend-api/projects/${project_id}/samples/${sample_id}/annotations`);
+}
+
 
 export default function SamplePage({ params }: Props) {
   const props = use(params);
@@ -184,8 +188,11 @@ export default function SamplePage({ params }: Props) {
     const project = await getProject(project_id);
     setProject(project);
 
-    const sample = await getSample(project_id, sample_id)
+    const sample = await getSample(project_id, sample_id);
     setSample(sample);
+
+    const annotations = await getAnnotations(project_id, sample_id);
+    setAnnotations(annotations);
     
     if (project.task == 'MHD') {
       viewParams.name = 'spectrogram';

--- a/services/ui/src/app/projects/[project_id]/samples/[sample_id]/page.tsx
+++ b/services/ui/src/app/projects/[project_id]/samples/[sample_id]/page.tsx
@@ -15,7 +15,7 @@ export const SampleDataBreadCrumbs = (info) => {
         <Breadcrumbs>
           <Item key="projects" href={`${process.env.NEXT_PUBLIC_API_URL}/projects`}>Projects</Item>
           <Item key="project" href={`${process.env.NEXT_PUBLIC_API_URL}/projects/${info.project._id}`}>Project: {info.project.name}</Item>
-          <Item key="samples">Sample: {info.sample.shot_id}</Item>
+          <Item key="samples">Shot: {info.sample.shot_id}</Item>
         </Breadcrumbs>
       </Provider>
   );

--- a/services/ui/src/app/projects/[project_id]/samples/[sample_id]/page.tsx
+++ b/services/ui/src/app/projects/[project_id]/samples/[sample_id]/page.tsx
@@ -98,30 +98,7 @@ function ToolBar({ project, sample_id, data, annotations, setAnnotations, viewPa
     tools.push(findPeaksTool); 
   } else if (project.task == 'MHD') {
 
-    const onTimeRangeChange = async (timeRange) => {
-        viewParams.time_min = timeRange.start;
-        viewParams.time_max = timeRange.end;
-        setViewParams(viewParams);
-    };
-
     let mhdData = data.values['mirnov'];
-    const timeRangeTool = (
-        <DataRangeSlider name={"Time Range"} data={mhdData.time} onChange={onTimeRangeChange} />
-    );
-
-    tools.push(timeRangeTool);
-
-    const onFrequencyRangeChange = async (freqRange) => {
-        viewParams.frequency_min = freqRange.start;
-        viewParams.frequency_max = freqRange.end;
-        setViewParams(viewParams);
-    };
-
-    const freqRangeTool = (
-        <DataRangeSlider name={"Frequency Range"} data={mhdData.frequency} onChange={onFrequencyRangeChange}/>
-    );
-
-    tools.push(freqRangeTool);
 
     const onAmplitudeRangeChange = async (ampRange) => {
         viewParams.amplitude_min = Math.pow(10, ampRange.start);

--- a/services/ui/src/app/projects/[project_id]/samples/[sample_id]/page.tsx
+++ b/services/ui/src/app/projects/[project_id]/samples/[sample_id]/page.tsx
@@ -23,7 +23,7 @@ export const SampleDataBreadCrumbs = (info) => {
 
 const SampleView = (args) => {
   if (args.project.task == 'disruption') {
-    return (<Disruption data={args.data}/>);
+    return (<Disruption data={args.data} annotations={args.annotations} setAnnotations={args.setAnnotations} />);
   } else if (args.project.task == 'ELM') {
     return (<ElmGraph data={args.data} annotations={args.annotations} setAnnotations={args.setAnnotations} />);
   } else if (args.project.task == 'MHD') {

--- a/services/ui/src/app/projects/[project_id]/samples/[sample_id]/page.tsx
+++ b/services/ui/src/app/projects/[project_id]/samples/[sample_id]/page.tsx
@@ -5,7 +5,7 @@ import { ElmGraph } from '@/app/elm/components/elms';
 import { getSample, getProject, getSampleData } from '@/app/core';
 import { use, useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import FindPeaksTool from '@/app/components/peaks';
+import { FindPeaksTool, TimeRangeSlider } from '@/app/components/peaks';
 import { LockedMode } from '@/app/locked-mode/components/locked-mode';
 
 export const SampleDataBreadCrumbs = (info) => {
@@ -26,7 +26,7 @@ const SampleView = (args) => {
   } else if (args.project.task == 'ELM') {
     return (<ElmGraph data={args.data} annotations={args.annotations} setAnnotations={args.setAnnotations}/>);
   } else if (args.project.task == 'MHD') {
-    return (<LockedMode data={args.data.values['mirnov']}/>);
+    return (<LockedMode data={args.data.values['mirnov']} viewParams={args.viewParams}/>);
   }
 }
 
@@ -85,16 +85,30 @@ export function SaveButton({project_id, sample_id, annotations}) {
 }
 
 
-function ToolBar({ project, sample_id, data, annotations, setAnnotations}) {
+function ToolBar({ project, sample_id, data, annotations, setAnnotations, viewParams, setViewParams}) {
   const project_id = project._id;
-  const findPeaksTool = (
-      <FindPeaksTool project_id={project_id} sample_id={sample_id} data={data} setAnnotations={setAnnotations}></FindPeaksTool>
-  );
+
 
   let tools = [];
   if (project.task == 'ELM') {
+    const findPeaksTool = (
+        <FindPeaksTool project_id={project_id} sample_id={sample_id} data={data} setAnnotations={setAnnotations}></FindPeaksTool>
+    );
     tools.push(findPeaksTool); 
-  } 
+  } else if (project.task == 'MHD') {
+
+    const onTimeRangeChange = async (timeRange) => {
+        viewParams.time_min = timeRange.start;
+        viewParams.time_max = timeRange.end;
+        setViewParams(viewParams);
+    };
+
+    let mhdData = data.values['mirnov'];
+    const timeRangeTool = (
+        <TimeRangeSlider data={mhdData} onChange={onTimeRangeChange} />
+    );
+    tools.push(timeRangeTool);
+  }
 
   return (
         <Provider theme={defaultTheme}>
@@ -127,7 +141,6 @@ async function getProject(project_id: string) {
 }
 
 
-
 export default function SamplePage({ params }: Props) {
   const props = use(params);
   const project_id = props.project_id;
@@ -137,37 +150,42 @@ export default function SamplePage({ params }: Props) {
   const [sample, setSample] = useState<any>(null);
   const [data, setData] = useState<any>(null);
   const [annotations, setAnnotations] = useState<any>([]);
+  const [viewParams, setViewParams] = useState<any>({name: 'identity'});
+
+  const refreshData = async ( viewParams ) => {
+    const project = await getProject(project_id);
+    setProject(project);
+
+    const sample = await getSample(project_id, sample_id)
+    setSample(sample);
+    
+    if (project.task == 'MHD') {
+      viewParams.name = 'spectrogram';
+      viewParams.nperseg = 256;
+      viewParams.amplitude_min = 1e-4;
+    }
+
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/backend-api/projects/${project_id}/samples/${sample_id}/data`, {
+        method: 'POST',
+        headers: {
+        'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(viewParams),
+    });
+    const data = await response.json();
+    setData(data);
+  };
 
   useEffect(() => {
-    const fetchData = async () => {
-      const project = await getProject(project_id);
-      setProject(project);
-
-      const sample = await getSample(project_id, sample_id)
-      setSample(sample);
-
-      let viewParams = null;
-      if (project.task == 'MHD') {
-        viewParams = {name: 'spectrogram', 'nperseg': 256, 'amplitude_min': 1e-4};
-      }
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/backend-api/projects/${project_id}/samples/${sample_id}/data`, {
-          method: 'POST',
-          headers: {
-          'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(viewParams),
-      });
-      const data = await response.json();
-      setData(data);
-    };
-
-    fetchData();
-  }, []);
+    const run = async () => {
+      await refreshData(viewParams);
+    }
+    run();
+  }, [viewParams]);
 
   if (!data) {
     return;
   }
-  console.log(data);
 
   return (
     <div>
@@ -175,9 +193,9 @@ export default function SamplePage({ params }: Props) {
         <ToastContainer placement="top" />
         <SampleDataBreadCrumbs project={project} sample={sample}></SampleDataBreadCrumbs>
           <div className='flex'>
-            <ToolBar project={project} sample_id={sample_id} data={data} annotations={annotations} setAnnotations={setAnnotations}/>
+            <ToolBar project={project} sample_id={sample_id} data={data} annotations={annotations} setAnnotations={setAnnotations} viewParams={viewParams} setViewParams={refreshData}/>
             <div className="flex-1 justify-center">
-              <SampleView project={project} data={data} annotations={annotations} setAnnotations={setAnnotations} />
+              <SampleView project={project} data={data} annotations={annotations} setAnnotations={setAnnotations}/>
             </div>
           </div>
       </Provider>

--- a/services/ui/src/app/projects/[project_id]/samples/[sample_id]/page.tsx
+++ b/services/ui/src/app/projects/[project_id]/samples/[sample_id]/page.tsx
@@ -5,7 +5,8 @@ import { ElmGraph } from '@/app/elm/components/elms';
 import { getSample, getProject, getSampleData } from '@/app/core';
 import { use, useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { FindPeaksTool, TimeRangeSlider } from '@/app/components/peaks';
+import { FindPeaksTool } from '@/app/components/peaks';
+import { DataRangeSlider } from '@/app/components/tools/dataRangeSlider';
 import { LockedMode } from '@/app/locked-mode/components/locked-mode';
 
 export const SampleDataBreadCrumbs = (info) => {
@@ -105,9 +106,36 @@ function ToolBar({ project, sample_id, data, annotations, setAnnotations, viewPa
 
     let mhdData = data.values['mirnov'];
     const timeRangeTool = (
-        <TimeRangeSlider data={mhdData} onChange={onTimeRangeChange} />
+        <DataRangeSlider name={"Time Range"} data={mhdData.time} onChange={onTimeRangeChange} />
     );
+
     tools.push(timeRangeTool);
+
+    const onFrequencyRangeChange = async (freqRange) => {
+        viewParams.frequency_min = freqRange.start;
+        viewParams.frequency_max = freqRange.end;
+        setViewParams(viewParams);
+    };
+
+    const freqRangeTool = (
+        <DataRangeSlider name={"Frequency Range"} data={mhdData.frequency} onChange={onFrequencyRangeChange}/>
+    );
+
+    tools.push(freqRangeTool);
+
+    const onAmplitudeRangeChange = async (ampRange) => {
+        viewParams.amplitude_min = Math.pow(10, ampRange.start);
+        viewParams.amplitude_max = Math.pow(10, ampRange.end);
+        setViewParams(viewParams);
+    };
+
+    let ampValues = mhdData.amplitude.flat();
+    ampValues = ampValues.map(x => Math.log10(Math.max(x, 1e-6)));
+    const ampRangeTool = (
+        <DataRangeSlider name={'Amplitude Range'} data={ampValues} onChange={onAmplitudeRangeChange} 
+        getValueLabel={val => `${Math.round(Math.pow(10, val.start)*10000, 2)/10000} - ${Math.round(Math.pow(10, val.end)*10000, 2)/10000}`}/>
+    );
+    tools.push(ampRangeTool);
   }
 
   return (
@@ -120,7 +148,7 @@ function ToolBar({ project, sample_id, data, annotations, setAnnotations, viewPa
             </ButtonGroup>
           </div>
           <hr className='m-4'/>
-          {tools.map((item, i) => <div className='h-screen' key={i}>{item}</div>)}
+          {tools.map((item, i) => <div  key={i}>{item}</div>)}
         </div>
         </Provider>
   );
@@ -162,7 +190,6 @@ export default function SamplePage({ params }: Props) {
     if (project.task == 'MHD') {
       viewParams.name = 'spectrogram';
       viewParams.nperseg = 256;
-      viewParams.amplitude_min = 1e-4;
     }
 
     const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/backend-api/projects/${project_id}/samples/${sample_id}/data`, {

--- a/services/ui/src/types.ts
+++ b/services/ui/src/types.ts
@@ -1,3 +1,21 @@
+import { z } from "zod/v4";
+
+export const Annotation = z.object({
+  timestamp: z.string().optional(),
+  validated: z.boolean().optional(),
+  uncertainty: z.number().optional(),
+  label: z.string()
+});
+
+export const TimeRegion = Annotation.extend({
+  time_min: z.number(),
+  time_max: z.number(),
+});
+
+export const TimePoint = Annotation.extend({
+  time: z.number(),
+});
+
 export type TimeSeriesData = Array<{
   time: number;
   value: number;
@@ -16,7 +34,6 @@ export type Category = {
 
 export type Zone = {
   category: Category;
-
   x0: number;
   x1: number;
 };

--- a/services/ui/src/types.ts
+++ b/services/ui/src/types.ts
@@ -3,11 +3,11 @@ export type TimeSeriesData = Array<{
   value: number;
 }>;
 
-export type SpectrogramData = Array<{
-  time: number;
-  frequency: number;
-  amplitude: number;
-}>;
+export type SpectrogramData = {
+  time: Array<number>;
+  frequency: Array<number>;
+  amplitude: Array<Array<number>>;
+};
 
 export type Category = {
   name: string;


### PR DESCRIPTION
**Do not merge before #36**

This PR adds support for saving and loading both VSpans and Zones at the same time. 

It also adds in some additional hooks to `VSpan` to capture when the annotation is add, moved, or deleted. 

I added support for the [zod](https://zod.dev/) for type validation so that we can distinguish between TimeRegion/TimePoint annotations when they are returned from the backend API.