### PR TITLE
Collapse single-category Add VSpan submenu 

### DIFF
--- a/services/ui/src/app/components/providers/vpsan-provider.tsx
+++ b/services/ui/src/app/components/providers/vpsan-provider.tsx
@@ -93,11 +93,29 @@ export const VSpanProvider = ({categories, initialData, children} : {
             )
         })
 
-        registerMenuItem("vspan", (
-            <Submenu key="vspan-submenu" label="Add VSpan">
-                {addVSpanItems}
-            </Submenu>
-        ))
+        /* Decide what to register in the main context-menu:
+            - When there is exactly one V-Span category (e.g. “Disruption”) show a single top-level Item “Add Disruption”.
+            - When there are multiple categories keep the existing “Add VSpan” submenu containing one Item per type.
+            - This prevents an unnecessary extra click in the single-category case.
+        */
+        const menuElement =
+            categories.length === 1
+                ? ( // single-category Case 
+                    <Item
+                        key="add-vspan-single"
+                        id="add-vspan-single"
+                        onClick={({props}) => {
+                            add(props.x0, categories[0])
+                        }}
+                    >
+                        {`Add ${categories[0].name}`}
+                    </Item>
+                ) : ( // multiple-category branch
+                    <Submenu key="vspan-submenu" label="Add VSpan">
+                        {addVSpanItems}
+                    </Submenu>
+                )
+        registerMenuItem("vspan", menuElement)
     }, [categories, registerMenuItem])
 
     // Initialisation of data - this should only run once

--- a/services/ui/src/app/components/providers/zone-provider.tsx
+++ b/services/ui/src/app/components/providers/zone-provider.tsx
@@ -108,12 +108,27 @@ export const ZoneProvider = ({categories, initialData, children, onModifyZone} :
                     </Item>
                 )
             })
-    
-            registerMenuItem("zone", (
-                <Submenu key="zone-submenu" label="Add zone">
-                    {addZoneItems}
-                </Submenu>
-            ))
+            
+            /* Decide what to register in the main context‑menu:
+           – Single category → direct “Add <Category>” item.
+           – Multiple categories → keep existing submenu.
+            */
+            const menuElement =
+                categories.length === 1
+                    ? (
+                        <Item key="add-zone-single" id="add-zone-single" onClick={({props}) => {
+                            add(props.x0, props.x1, categories[0])
+                        }}>
+                            {`Add ${categories[0].name}`}
+                        </Item>
+                    ) : (
+                        <Submenu key="zone-submenu" label="Add zone">
+                            {addZoneItems}
+                        </Submenu>
+                    )
+
+            registerMenuItem("zone", menuElement)
+
         }, [categories, registerMenuItem])
 
     // Initialisation of data - this should only run once


### PR DESCRIPTION
This change updates VSpanProvider to address issue https://github.com/ukaea/viz-annotation/issues/19 so that when only one V-Span category exists (e.g. “Disruption”) the context-menu registers a single top-level Item (“Add Disruption”) instead of a Submenu with a lone child. The provider now checks categories.length; if it equals 1 it renders the direct item, otherwise it falls back to the original submenu logic for multi-category tools. This removes an unnecessary click for users without altering behaviour where multiple V-Span types are present. No other components are touched and the API for registering V-Spans remains unchanged.