### PR TITLE
Fix missing context menu handlers

### DIFF
--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -174,9 +174,9 @@ export const TimeSeries = ({
             })
         }
 
-        const dragElement = plot.querySelector(".drag")
+        const dragElements = plot.querySelectorAll(".drag")
 
-        if (!dragElement) {
+        if (dragElements.length === 0) {
             console.error("Could not locate drag element to assign context menu")
             return
         }
@@ -185,10 +185,14 @@ export const TimeSeries = ({
             handleContextMenu(event, plot)
         } 
 
-        dragElement.addEventListener("contextmenu", contextHandler) // add context-menu listener
+        dragElements.forEach((dragElement) => {
+            dragElement.addEventListener("contextmenu", contextHandler) // add context-menu listener
+        })
 
         return () => { // remove listener on effect cleanup
-            dragElement.removeEventListener("contextmenu", contextHandler) 
+            dragElements.forEach((dragElement) => {
+                dragElement.removeEventListener("contextmenu", contextHandler)
+            })
         }
 
     }, [plotId, plotReady])


### PR DESCRIPTION
It was noticed that there appears to have been a regression in the context menu handling across subplotting.

The issue was that the context menu handler was not being assigned to all subplots - I am unsure why this was working before to be honest.

The solution was to query all selectors with the required class rather than just the first one.