### PR TITLE
Auto scaling

### DIFF
--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -108,13 +108,17 @@ export const TimeSeries = ({
                     }
                 }
 
+                const xArray = (dataSet as PlotData).x as number[];
+                const yArray = (dataSet as PlotData).y as number[];
+
                 // Find min and max y data values
                 const yValues: number[] = [];
-                ((dataSet as PlotData).x as number[]).forEach((xVal, i) => {
+                for (let i = 0; i < xArray.length; i++) {
+                    const xVal = xArray[i];
                     if (xVal >= x0 && xVal <= x1) {
-                        yValues.push(((data[index] as PlotData).y as number[])[i])
+                        yValues.push(yArray[i]);
                     }
-                })
+                }
 
                 if (yValues.length > 0) {
                     const yMin = Math.min(...yValues)

--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -119,7 +119,6 @@ export const TimeSeries = ({
                 if (yValues.length > 0) {
                     const yMin = Math.min(...yValues)
                     const yMax = Math.max(...yValues)
-                    console.log(yMin, yMax)
 
                     const previousRange = (plot as any)._fullLayout[`yaxis${yAxisID}`].range;
                     

--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useContextMenuProvider } from "@/app/components/providers/context-menu-provider"
-import { Config, Layout, Data } from "plotly.js"
+import { Config, Layout, PlotData, relayout, PlotRelayoutEvent } from "plotly.js"
 import React, { useEffect, useRef, useState } from "react"
 
 type InjectedProps = {
@@ -11,7 +11,7 @@ type InjectedProps = {
 }
 
 interface PlotConfiguration {
-    data: Data[],
+    data: Partial<PlotData>[],
     layout: Partial<Layout>,
     config?: Partial<Config>
 }
@@ -51,6 +51,8 @@ export const TimeSeries = ({
 
     const overplots: string[] = [];
 
+    let allowRelayout = true;
+
     const triggerToolUpdate = () => {
         setUpdateTools((current) => (current + 1) % 100)
     }
@@ -81,10 +83,73 @@ export const TimeSeries = ({
         
         setPlotReady(true)
 
-        const relayoutHandler = () => { // triggers re-render of overlay tools when axes change
+        // Sets the y axis range required for the current x range for each subplot
+        const rescale = (x0?: number, x1?: number, manualZoom = false) => {
+            if (!allowRelayout) return // Prevents relayout triggering itself
+            allowRelayout = false
+
+            // If no x range is passed, then the min/max is used
+            if (!x0) {
+                x0 = ((plot as any)._fullData[0]._extremes.x.min[0].val) as number;
+            }
+            if (!x1) {
+                x1 = ((plot as any)._fullData[0]._extremes.x.max[0].val) as number;
+            }
+            
+            // Ensure each data set is handled (ensures all subplots are zoomed correctly)
+            data.forEach((dataSet, index) => {
+                let yAxisID = ""
+
+                if (dataSet.yaxis) {
+                    // Find the y axis ID relating to this subplot
+                    const locatedID = dataSet.yaxis.match(/y(.*)$/)?.[1];
+                    if (locatedID) {
+                        yAxisID = locatedID
+                    }
+                }
+
+                // Find min and max y data values
+                const yValues: number[] = [];
+                ((dataSet as PlotData).x as number[]).forEach((xVal, i) => {
+                    if (xVal >= x0 && xVal <= x1) {
+                        yValues.push(((data[index] as PlotData).y as number[])[i])
+                    }
+                })
+
+                if (yValues.length > 0) {
+                    const yMin = Math.min(...yValues)
+                    const yMax = Math.max(...yValues)
+                    console.log(yMin, yMax)
+
+                    const previousRange = (plot as any)._fullLayout[`yaxis${yAxisID}`].range;
+                    
+                    // Only allow relayout if new yRange is smaller than previous one or if this isn't a manual zoom
+                    // This allows users to zoom in on bits of the graph accurately without it auto-scaling
+                    if (((yMax - yMin) < (previousRange[1] - previousRange[0]) || !manualZoom)) {
+                        relayout(plot, {
+                            [`yaxis${yAxisID}.range`]: [yMin, yMax]
+                        })
+                    }
+                }
+            })
+
+            // Debounce the relayout calls 
+            setTimeout(() => {
+                allowRelayout = true
+            }, 100)
+        }
+
+        const relayoutHandler = (eventData: PlotRelayoutEvent) => { // triggers re-render of overlay tools when axes change
             triggerToolUpdate()
+
+            // This makes use of the first graph displayed but this should be fine
+            const x0 = eventData["xaxis.range[0]"];
+            const x1 = eventData["xaxis.range[1]"];
+
+            rescale(x0, x1, true)
         } 
         plot.on("plotly_relayout", relayoutHandler) // attach listener so it can be removed
+        plot.on("plotly_doubleclick", rescale)
 
         document.addEventListener("keydown", (e) => {
             if (e.key === "Shift") {

--- a/services/ui/src/app/demos/time-series/components/time-series.tsx
+++ b/services/ui/src/app/demos/time-series/components/time-series.tsx
@@ -39,7 +39,7 @@ export const TimeSeriesDemo = ({ data }: DisruptionInfo) => {
     const time = useRef(data.map(({ time }) => time));
     const value = useRef(data.map(({ value }) => value));
 
-    const plotData: Plotly.Data[] = [
+    const plotData: Partial<Plotly.PlotData>[] = [
         {
             x: time.current,
             y: value.current,

--- a/services/ui/src/app/disruption/components/disruption.tsx
+++ b/services/ui/src/app/disruption/components/disruption.tsx
@@ -34,7 +34,7 @@ export const Disruption = ({ data }: DisruptionInfo) => {
         { x: 0.3, category: disruptionCategories[0] }
     ]
 
-    const plotData: Plotly.Data[] = [
+    const plotData: Partial<Plotly.PlotData>[] = [
         {
             x: data.values['ip'].time,
             y: data.values['ip'].values,

--- a/services/ui/src/app/elm/components/elms.tsx
+++ b/services/ui/src/app/elm/components/elms.tsx
@@ -52,7 +52,7 @@ export const ElmGraph = ({data, annotations, setAnnotations}) => {
         mode: 'lines',
     };
 
-    const plotData: Plotly.Data[] = [dataTrace, ipTrace, densityGradientTrace, powerNBITrace, t_e_coreTrace];
+    const plotData: Partial<Plotly.PlotData>[] = [dataTrace, ipTrace, densityGradientTrace, powerNBITrace, t_e_coreTrace];
 
 
     var plotLayout = {

--- a/services/ui/src/app/locked-mode/components/locked-mode.tsx
+++ b/services/ui/src/app/locked-mode/components/locked-mode.tsx
@@ -47,7 +47,7 @@ export const LockedMode = ({ data, annotations, setAnnotations }: {data: LockedM
     let ticktext = tickvals.map(x => Math.pow(10, x));
     ticktext = ticktext.map(x => Math.round(x * 10000) / 10000);
 
-    const plotData: Plotly.Data[] = [{
+    const plotData: Partial<Plotly.PlotData>[] = [{
         name: "Saddle Coil FFT",
         type: 'heatmap',
         x: data.time,


### PR DESCRIPTION
Closes #29 

When zooming in on a plot, it has been identified that it is beneficial for the Y-Scale of the graph to automatically zoom to fit the data shown in the currently selected x-range as demonstrated in the clip below:

https://github.com/user-attachments/assets/4ffb5353-0eca-4b01-b43f-6468fcf38936

This works for subplotting with shared x-axes, a potential issue is that this is designed only for shared x-axes.

Additionally it should be noted that auto-scaling will not occur if it would lead to the y-scale being tighter than the user selection. This is to allow users to accurately target data.