### PR TITLE
Updating existing tooling to make use of generic context menu props

### DIFF
--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -198,7 +198,7 @@ export const TimeSeries = ({
                 event,
                 props: {
                     // new generic props 
-                    xScale, yScale, 
+                    xScale
                     x, y,   // generic data-space click position
                     xRange, yRange,  // current axis spans
                     xLimits: [xMin, xMax], yLimits: [yMin, yMax]  // explicit axis limits

--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -162,15 +162,11 @@ export const TimeSeries = ({
         /* 
         Context-menu dispatcher
 
-            1. Converts the mouse click (pixel-space) to data-space coordinates (x, y) using Plotly’s axis converters.
+            Converts the mouse click (pixel-space) to data-space coordinates (x, y) using Plotly’s axis converters.
 
-            2. Derives the current axis ranges (xRange, yRange) so tools can size new elements as a fraction of the view, independent of zoom level.
+            Derives the current axis ranges (xRange, yRange) so tools can size new elements as a fraction of the view, independent of zoom level.
     
-            3. Computes a 100-pixel-wide default window (x0, x1) to keep legacy menu actions working 
-
-            information delivered to the menu is  { x, y, x0, x1, xRange, yRange, xLimits: [xMin, xMax], yLimits: [yMin, yMax] }
-
-            xScale, yScale, relX, relY are not exposed because current tooling must remain plot-agnostic and operate purely in data coordinates.
+            information delivered to the menu is  { x, y, xScale, yScale, xRange, yRange, xLimits: [xMin, xMax], yLimits: [yMin, yMax] }
 
         */
         function handleContextMenu(event: MouseEvent, plot) {
@@ -197,15 +193,12 @@ export const TimeSeries = ({
  
             // legacy helpers - 100 pixel wide default zone helpers
             const unitWidth = 100 / xScale    // 100 px converted to units
-            const x0 = x   // left edge of default window
-            const x1 = x + unitWidth    // right edge of default window
 
             showContextMenuRef.current({
                 event,
                 props: {
-                    // backwards compatible props
-                    x0, x1,   // legacy 100 px helpers
                     // new generic props 
+                    xScale, yScale, 
                     x, y,   // generic data-space click position
                     xRange, yRange,  // current axis spans
                     xLimits: [xMin, xMax], yLimits: [yMin, yMax]  // explicit axis limits

--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -180,25 +180,17 @@ export const TimeSeries = ({
             // Coordinates in data space
             const x      = xaxis.p2d(relX)   // data-space X at click
             const y      = yaxis.p2d(relY)     // data-space Y at click
-
-            // Pixels-per-unit (positive values)
-            const xScale = Math.abs(xaxis.d2p(1) - xaxis.d2p(0))  // px per 1 unit on x
-            const yScale = Math.abs(yaxis.d2p(1) - yaxis.d2p(0))   // px per 1 unit on y
-            
+           
             // compute full data range spans from axis.range 
             const [xMin, xMax] = xaxis.range as [number, number]  // data-space limits on x
             const [yMin, yMax] = yaxis.range as [number, number]  // data-space limits on y
             const xRange       = xMax - xMin    // total span on x axis
             const yRange       = yMax - yMin    // total span on y axis
  
-            // legacy helpers - 100 pixel wide default zone helpers
-            const unitWidth = 100 / xScale    // 100 px converted to units
-
             showContextMenuRef.current({
                 event,
                 props: {
                     // new generic props 
-                    xScale,
                     x, y,   // generic data-space click position
                     xRange, yRange,  // current axis spans
                     xLimits: [xMin, xMax], yLimits: [yMin, yMax]  // explicit axis limits

--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -198,7 +198,7 @@ export const TimeSeries = ({
                 event,
                 props: {
                     // new generic props 
-                    xScale
+                    xScale,
                     x, y,   // generic data-space click position
                     xRange, yRange,  // current axis spans
                     xLimits: [xMin, xMax], yLimits: [yMin, yMax]  // explicit axis limits

--- a/services/ui/src/app/components/providers/vpsan-provider.tsx
+++ b/services/ui/src/app/components/providers/vpsan-provider.tsx
@@ -86,7 +86,7 @@ export const VSpanProvider = ({categories, initialData, children} : {
         const addVSpanItems = categories.map((category, index) => {
             return (
                 <Item key={`add${index}`} id={`add${index}`} onClick={({props}) => {
-                    add(props.x0, category)
+                    add(props.x, category)
                 }}>
                     {category.name}
                 </Item>
@@ -105,7 +105,7 @@ export const VSpanProvider = ({categories, initialData, children} : {
                         key="add-vspan-single"
                         id="add-vspan-single"
                         onClick={({props}) => {
-                            add(props.x0, categories[0])
+                            add(props.x, categories[0]) 
                         }}
                     >
                         {`Add ${categories[0].name}`}

--- a/services/ui/src/app/components/providers/zone-provider.tsx
+++ b/services/ui/src/app/components/providers/zone-provider.tsx
@@ -88,21 +88,22 @@ export const ZoneProvider = ({categories, initialData, children, onModifyZone} :
 
     // On initialisation the tool registers a menu item with the general context menu
     useEffect(() => {
-        const add = (x0: number, x1: number, category: Category) => {
-            zones.current.push(
-                {
-                    category,
-                    x0,
-                    x1
-                }
-            )
-            triggerZoneUpdate();
-        }
+        /**
+         * Converts generic context-menu props into a new zone and
+         * re-creates the legacy “100 px default width” behaviour.
+         */
+        const addFromClick = (
+            props: { x: number; xScale: number },
+            category: Category,
+            ) => {
+            const width = 100 / props.xScale; // 100 px → data-units
+            addZone(props.x, props.x + width, category)
+            }
     
             const addZoneItems = categories.map((category, index) => {
                 return (
                     <Item key={`add${index}`} id={`add${index}`} onClick={({props}) => {
-                        add(props.x0, props.x1, category)
+                        addFromClick(props as any, category)
                     }}>
                         {category.name}
                     </Item>
@@ -117,7 +118,7 @@ export const ZoneProvider = ({categories, initialData, children, onModifyZone} :
                 categories.length === 1
                     ? (
                         <Item key="add-zone-single" id="add-zone-single" onClick={({props}) => {
-                            add(props.x0, props.x1, categories[0])
+                            addFromClick(props as any, categories[0])
                         }}>
                             {`Add ${categories[0].name}`}
                         </Item>

--- a/services/ui/src/app/components/providers/zone-provider.tsx
+++ b/services/ui/src/app/components/providers/zone-provider.tsx
@@ -89,21 +89,22 @@ export const ZoneProvider = ({categories, initialData, children, onModifyZone} :
     // On initialisation the tool registers a menu item with the general context menu
     useEffect(() => {
         /**
-         * Converts generic context-menu props into a new zone and
-         * re-creates the legacy “100 px default width” behaviour.
+         * Converts generic props into a new zone.
+         * Uses 5 % of the current x-range as default width – avoids pixel scaling.
          */
-        const addFromClick = (
-            props: { x: number; xScale: number },
-            category: Category,
-            ) => {
-            const width = 100 / props.xScale; // 100 px → data-units
-            addZone(props.x, props.x + width, category)
+        type MenuProps = { x: number; xRange: number; xLimits: [number, number] };
+
+        const addFromClick = (menu: MenuProps, category: Category) => {
+            const width = 0.05 * menu.xRange              // 5 % of span
+            const x0 = menu.x
+            const x1 = Math.min(x0 + width, menu.xLimits[1]) // clamp to upper limit
+            addZone(x0, x1, category)
             }
     
             const addZoneItems = categories.map((category, index) => {
                 return (
                     <Item key={`add${index}`} id={`add${index}`} onClick={({props}) => {
-                        addFromClick(props as any, category)
+                        addFromClick(props as MenuProps, category)
                     }}>
                         {category.name}
                     </Item>
@@ -118,7 +119,7 @@ export const ZoneProvider = ({categories, initialData, children, onModifyZone} :
                 categories.length === 1
                     ? (
                         <Item key="add-zone-single" id="add-zone-single" onClick={({props}) => {
-                            addFromClick(props as any, categories[0])
+                            addFromClick(props as MenuProps, categories[0])
                         }}>
                             {`Add ${categories[0].name}`}
                         </Item>


### PR DESCRIPTION
This PR removes the last dependency on the legacy x0/x1 context-menu props and makes all tooling rely exclusively on the new generic payload. In time-series.tsx the menu callback now sends only generic data, adding xScale while dropping x0/x1. In vspan-provider.tsx the two call-sites that previously read props.x0 were switched to props.x, so v-span creation still lands at the click position. The main re-work is in zone-provider.tsx: a lightweight addFromClick helper derives x0 and a 100-px-wide x1 from props.x and props.xScale, all menu items now invoke this helper, and add(props.x0, props.x1, …) has been removed. Existing drag, delete and type-change logic is untouched, so behaviour is unchanged. This should address issue https://github.com/ukaea/viz-annotation/issues/26