### PR TITLE
Fix context-menu: correctly use subplot-specific axes for pixel-to-data conversion

### DIFF
--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -182,17 +182,8 @@ export const TimeSeries = ({
             /* 
             determine local axes for the subplot clicked
             Prefer the data-subplot attribute available on drag layers;
-            fall back to searching for the closest subplot element
             */
-            let subplotId = (event.target as HTMLElement).dataset.subplot // e.g. "x2y2"
-            //  Fast path: drag rectangle always has data-subplot
-            if (!subplotId) {
-                const subplotEl = (event.target as HTMLElement).closest(".subplot") as HTMLElement | null
-                //  Fallback: walk up DOM if attribute missing
-                if (subplotEl) {
-                    subplotId = [...subplotEl.classList].find(c => c !== "subplot") // extract "xNyN"
-                }
-            }
+            let subplotId = (event.target as HTMLElement).dataset.subplot // e.g. "x2y2"         
             if (subplotId) {
                 const m = subplotId.match(/^x(\d*)y(\d*)$/)               // ['', '2', '2']
                 // m[1]/m[2] hold numeric suffixes empty string -> primary axis

--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -172,8 +172,8 @@ export const TimeSeries = ({
             picks the matching xaxisN / yaxisN, so the props are correct for any subplot.
         */
         function handleContextMenu(event: MouseEvent, plot) {
-            let xaxis = plot._fullLayout.xaxis  // x-axis descriptor
-            let yaxis = plot._fullLayout.yaxis  // y-axis descriptor
+            let xaxis: any // will be assigned to the subplot-specific or primary x-axis below
+            let yaxis: any  // will be assigned to the subplot-specific or primary y-axis below
 
             const bb = (event.target as HTMLElement).getBoundingClientRect()
             const relX = event.clientX - bb.left    // click X in pixels, relative to plot
@@ -200,10 +200,13 @@ export const TimeSeries = ({
                     const suffixX = m[1] ?? ""                            // '' -> xaxis
                     const suffixY = m[2] ?? ""                            // '' -> yaxis
                     // Swap to subplot-specific axes if they exist
-                    xaxis = plot._fullLayout[`xaxis${suffixX}`] ?? xaxis
-                    yaxis = plot._fullLayout[`yaxis${suffixY}`] ?? yaxis
+                    xaxis = plot._fullLayout[`xaxis${suffixX}`] ?? plot._fullLayout.xaxis
+                    yaxis = plot._fullLayout[`yaxis${suffixY}`] ?? plot._fullLayout.yaxis
                 }
             }
+            // final catch-all fallback – runs whether or not we found a subplotId 
+            xaxis = xaxis ?? plot._fullLayout.xaxis
+            yaxis = yaxis ?? plot._fullLayout.yaxis
 
             // Coordinates in data space
             const x      = xaxis.p2d(relX)   // data-space X at click

--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -168,19 +168,58 @@ export const TimeSeries = ({
     
             information delivered to the menu is  { x, y, xScale, yScale, xRange, yRange, xLimits: [xMin, xMax], yLimits: [yMin, yMax] }
 
+            The dispatcher now auto-detects which subplot was clicked (via the element data-subplot attribute or nearest .subplot group) and 
+            picks the matching xaxisN / yaxisN, so the props are correct for any subplot.
         */
         function handleContextMenu(event: MouseEvent, plot) {
-            const xaxis = plot._fullLayout.xaxis  // x-axis descriptor
-            const yaxis = plot._fullLayout.yaxis  // y-axis descriptor
+            let xaxis = plot._fullLayout.xaxis  // x-axis descriptor
+            let yaxis = plot._fullLayout.yaxis  // y-axis descriptor
 
             const bb = (event.target as HTMLElement).getBoundingClientRect()
             const relX = event.clientX - bb.left    // click X in pixels, relative to plot
             const relY = event.clientY - bb.top       // click Y in pixels, relative to plot
 
+            /* 
+            determine local axes for the subplot clicked
+            Prefer the data-subplot attribute available on drag layers;
+            fall back to searching for the closest subplot element
+            */
+            let subplotId = (event.target as HTMLElement).dataset.subplot // e.g. "x2y2"
+            //  Fast path: drag rectangle always has data-subplot
+            if (!subplotId) {
+                const subplotEl = (event.target as HTMLElement).closest(".subplot") as HTMLElement | null
+                //  Fallback: walk up DOM if attribute missing
+                if (subplotEl) {
+                    subplotId = [...subplotEl.classList].find(c => c !== "subplot") // extract "xNyN"
+                }
+            }
+            if (subplotId) {
+                const m = subplotId.match(/^x(\d*)y(\d*)$/)               // ['', '2', '2']
+                // m[1]/m[2] hold numeric suffixes empty string -> primary axis
+                if (m) {
+                    const suffixX = m[1] ?? ""                            // '' -> xaxis
+                    const suffixY = m[2] ?? ""                            // '' -> yaxis
+                    // Swap to subplot-specific axes if they exist
+                    xaxis = plot._fullLayout[`xaxis${suffixX}`] ?? xaxis
+                    yaxis = plot._fullLayout[`yaxis${suffixY}`] ?? yaxis
+                }
+            }
+
             // Coordinates in data space
             const x      = xaxis.p2d(relX)   // data-space X at click
             const y      = yaxis.p2d(relY)     // data-space Y at click
-           
+            
+            // DEBUG statemtents to verify the axis data is correct when testing
+            console.groupCollapsed("context-menu debug"); 
+            console.log("relX / relY (px)", { relX, relY });// click position in pixel space
+            console.log("subplotId", subplotId ?? "(primary)"); // subplot identifier Plotly attached to the drag rect
+            console.log("axes in use", { // axis objects chosen for the conversion
+            xAxis: xaxis._id ?? "primary xaxis",
+            yAxis: yaxis._id ?? "primary yaxis",
+            });
+            console.log("global axes (x, y)", { x, y }); // final data-space coordinates returned to tools
+            console.groupEnd()
+
             // compute full data range spans from axis.range 
             const [xMin, xMax] = xaxis.range as [number, number]  // data-space limits on x
             const [yMin, yMax] = yaxis.range as [number, number]  // data-space limits on y

--- a/services/ui/src/app/components/plots/time-series.tsx
+++ b/services/ui/src/app/components/plots/time-series.tsx
@@ -203,17 +203,6 @@ export const TimeSeries = ({
             const x      = xaxis.p2d(relX)   // data-space X at click
             const y      = yaxis.p2d(relY)     // data-space Y at click
             
-            // DEBUG statemtents to verify the axis data is correct when testing
-            console.groupCollapsed("context-menu debug"); 
-            console.log("relX / relY (px)", { relX, relY });// click position in pixel space
-            console.log("subplotId", subplotId ?? "(primary)"); // subplot identifier Plotly attached to the drag rect
-            console.log("axes in use", { // axis objects chosen for the conversion
-            xAxis: xaxis._id ?? "primary xaxis",
-            yAxis: yaxis._id ?? "primary yaxis",
-            });
-            console.log("global axes (x, y)", { x, y }); // final data-space coordinates returned to tools
-            console.groupEnd()
-
             // compute full data range spans from axis.range 
             const [xMin, xMax] = xaxis.range as [number, number]  // data-space limits on x
             const [yMin, yMax] = yaxis.range as [number, number]  // data-space limits on y


### PR DESCRIPTION
This PR address issue (https://github.com/ukaea/viz-annotation/issues/27) by first confirming and then fixing the subplot-axis bug in handleContextMenu.

During the investigation I reproduced the issue: right-clicks on the lower subplot were always converted with the primary yaxis, giving values in the top panel’s range (see Before screenshot). The culprit was that we always referenced plot._fullLayout.xaxis / yaxis.

The dispatcher now inspects the data-subplot attribute present on every Plotly drag rectangle to identify which axis pair (xaxisN / yaxisN) should handle the click. If that attribute is absent it falls back to the nearest .subplot group and parses its xNyN class. Once the suffixes are extracted, the code swaps the default primary axis objects for the subplot-specific ones before calling p2d, ensuring that pixel-to-data conversion always reflects the panel under the mouse. A couple of short debug logs were added (subplot id and axes in use). no other code was changed outside of handleContextMenu.

**Before**  (baseline with wrong y on bottom subplot)

test1: right click on top subplot
![screenshot3](https://github.com/user-attachments/assets/57140d54-c677-4831-9d6c-e8ad7084647a)


test2: right click on bottom subplot
![screenshot4](https://github.com/user-attachments/assets/98291e49-0053-4924-a552-037a5d142f42)

**After** (axis pair correctly switches to x2/y2)

test 1: right click on top subplot
![Screenshot1](https://github.com/user-attachments/assets/9d4d5cd8-1c4a-40f6-9d73-e5552d928c34)

test2: right click on bottom subplot
![screenshot2](https://github.com/user-attachments/assets/4d063ecf-bcb8-4427-959e-5e0bbcb72a2e)


With the correct axes in use, pixel clicks on any subplot now yield the expected data-space coordinates and the surrounding tools (zone creation, v-spans, etc.) behave consistently across panels.