### PR TITLE
Remove NEXT_PUBLIC_API_URL as it causes CORS issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       PORT: 3001
       NODE_ENV: development
       DATA_API_URL: "http://api_app:8002"
-      NEXT_PUBLIC_API_URL: "http://localhost:3001"
+      NEXT_PUBLIC_API_URL: ""
     volumes:
       - ./services/ui:/app
       - /app/node_modules

--- a/services/api/crud/utils.py
+++ b/services/api/crud/utils.py
@@ -6,6 +6,7 @@ from services.api.schemas.annotations import Annotation
 from services.api.schemas.projects import Project
 from services.api.schemas.samples import Sample
 
+
 async def get_project(db_client: MongoDBClient, project_id: str) -> Project:
     obj_id = convert_to_objectid(project_id, "projects")
 
@@ -41,8 +42,7 @@ async def get_annotations(
     project_id: str,
     validated: Optional[bool] = None,
     sort_by: str = "_id",
-    sort_direction: Literal["ascending", "descending"] = "descending", 
-
+    sort_direction: Literal["ascending", "descending"] = "descending",
     start: int = 0,
     count: Optional[int] = None,
 ) -> list[Annotation]:
@@ -62,22 +62,22 @@ async def get_annotations(
 
 
 async def get_samples(
-    db_client: MongoDBClient, 
-    project_id: str, 
-    shot_id: int = None,
-    sort_by: str = "_id", 
-    sort_direction: Literal["ascending", "descending"] = "descending", 
-    start: int = 0, 
-    count: Optional[int] = None
+    db_client: MongoDBClient,
+    project_id: str,
+    shot_id: Optional[int] = None,
+    sort_by: str = "_id",
+    sort_direction: Literal["ascending", "descending"] = "descending",
+    start: int = 0,
+    count: Optional[int] = None,
 ) -> list[Sample]:
     # Return a list of all samples for this project and info about them
     project_obj_id = convert_to_objectid(project_id, "projects")
 
     if not await db_client.get_document_by_id("projects", project_obj_id):
         raise HTTPException(status_code=404, detail="Project not found with that ID.")
-    
+
     filters = {"project_id": project_obj_id}
-    
+
     if shot_id:
         filters["shot_id"] = shot_id
 

--- a/services/api/crud/utils.py
+++ b/services/api/crud/utils.py
@@ -64,7 +64,7 @@ async def get_annotations(
 async def get_samples(
     db_client: MongoDBClient, 
     project_id: str, 
-    shot_id: int,
+    shot_id: int = None,
     sort_by: str = "_id", 
     sort_direction: Literal["ascending", "descending"] = "descending", 
     start: int = 0, 


### PR DESCRIPTION
Not sure if this is an appropriate solution, but it seems to work...

The code in `services/ui/next_config.js` already overwrites the location of the backend API to point to the docker container as far as I can tell, so dont think we need to provide anything to `NEXT_PUBLIC_API_URL`. It causes CORS issues when trying to load the web UI on `127.0.0.1` or on the VM, since it tries to point to localhost from a different origin. Tried adding CORSMiddleware from FastAPI but that also doesnt work, I think since the browser doesnt add an `Origin` header for some reason and therefore CORSMiddleware doesnt kick in....

Closes #67 