### PR TITLE
Hotfix for setup script and UI

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -32,7 +32,7 @@ def create_uda_samples(project_id: str, shot_ids: list[int]):
         }
         samples.append(sample)
 
-    requests.put(f"http://localhost:8002/projects/{project_id}/samples", json=samples)
+    requests.post(f"http://localhost:8002/projects/{project_id}/samples", json=samples)
 
 
 def create_local_samples(
@@ -57,7 +57,7 @@ def create_local_samples(
         }
         samples.append(sample)
 
-    requests.put(f"http://localhost:8002/projects/{project_id}/samples", json=samples)
+    requests.post(f"http://localhost:8002/projects/{project_id}/samples", json=samples)
 
 
 def main():

--- a/services/ui/src/app/components/tools/toolbar.tsx
+++ b/services/ui/src/app/components/tools/toolbar.tsx
@@ -20,7 +20,7 @@ import { DataRangeSlider } from '@/app/components/tools/dataRangeSlider';
 async function saveAnnotations(project_id: string, sample_id: string, annotations: Annotations) {
     const ANNOTATIONS_URL = `${process.env.NEXT_PUBLIC_API_URL}/backend-api/projects/${project_id}/samples/${sample_id}/annotations`;
     const response = await fetch(ANNOTATIONS_URL, {
-        method: 'POST',
+        method: 'PUT',
         headers: {
         'Content-Type': 'application/json',
         },


### PR DESCRIPTION
In the PR adding the tests, I changed the create new samples endpoint from PUT to POST. Forgot to change the setup script, so this was just getting 405 errors back when trying to create samples

Also erroneously changed the update annotations endpoint from PUT to POST in the UI code - this annotations endpoint remained a PUT since it deletes the old annotations before creating new ones. Fixed this in the UI code

This demonstrates that we really need full end-to-end tests of the UI and backend API - raised https://github.com/ukaea/viz-annotation/issues/101