### PR TITLE
Add github release creation to publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,3 +74,33 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-github-release:
+    name: Create Signed GitHub Release
+    needs: [build, publish-to-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "TokTagger ${{ github.ref_name }}"
+          generate_release_notes: true
+          files: dist/**
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds github release creation and upload of signed artifacts to release

(ps, never used this `softprops/action-gh-release@v2` action before, so not sure if this will work or not! No way to test until we try a release....)