### PR TITLE
Add dataloader worker registry and refactor dataloaders

### DIFF
--- a/docs/custom_dataloaders.md
+++ b/docs/custom_dataloaders.md
@@ -206,7 +206,7 @@ class CSVTimeSeriesLoader(DataLoader):
     def get_sample(
         self, 
         sample: Sample,
-        params: DataParams,
+        params: DataParams = DataParams(),
     ) -> MultiVariateTimeSeriesData:
         """
         Load time series data from a CSV file.
@@ -323,7 +323,7 @@ class SQLDatabaseLoader(DataLoader):
     def get_sample(
         self, 
         sample: Sample,
-        params: DataParams, 
+        params: DataParams = DataParams(), 
     ) -> MultiVariateTimeSeriesData:
         """Load time series data from database"""
         results = {}

--- a/docs/custom_dataloaders.md
+++ b/docs/custom_dataloaders.md
@@ -190,7 +190,7 @@ import pydantic
 
 from toktagger.api.core.data_loaders import DataLoader, LoaderRegistry
 from toktagger.api.schemas.data import MultiVariateTimeSeriesData, TimeSeriesData
-from toktagger.api.schemas.samples import TimeSeriesFileData
+from toktagger.api.schemas.samples import Sample, TimeSeriesFileData
 
 
 @LoaderRegistry.register("csv_timeseries")
@@ -205,8 +205,8 @@ class CSVTimeSeriesLoader(DataLoader):
     @pydantic.validate_call
     def get_sample(
         self, 
-        shot_id: int, 
-        sample_data: TimeSeriesFileData
+        sample: Sample,
+        params: DataParams,
     ) -> MultiVariateTimeSeriesData:
         """
         Load time series data from a CSV file.
@@ -216,7 +216,7 @@ class CSVTimeSeriesLoader(DataLoader):
         - Remaining columns: signal values with column headers
         """
         # Verify file exists
-        file_path = pathlib.Path(sample_data.file_name)
+        file_path = pathlib.Path(sample.data.file_name)
         if not file_path.exists():
             raise FileNotFoundError(
                 f"Could not find CSV file at '{file_path}'"
@@ -226,7 +226,7 @@ class CSVTimeSeriesLoader(DataLoader):
         df = pd.read_csv(file_path, index_col=0)  # First column is time
         
         # Filter to requested signals if specified
-        if sample_data.signal_names:
+        if sample.data.signal_names:
             df = df[sample_data.signal_names]
         
         # Handle missing values
@@ -300,7 +300,7 @@ from typing import Type
 import pydantic
 
 from toktagger.api.core.data_loaders import DataLoader, LoaderRegistry
-from toktagger.api.schemas.data import MultiVariateTimeSeriesData, TimeSeriesData
+from toktagger.api.schemas.data import MultiVariateTimeSeriesData, TimeSeriesData, DataParams
 from toktagger.api.schemas.samples import ShotData
 
 
@@ -308,13 +308,12 @@ from toktagger.api.schemas.samples import ShotData
 class SQLDatabaseLoader(DataLoader):
     """DataLoader for retrieving data from a SQL database"""
     
-    def __init__(self, params):
+    def __init__(self):
         # Initialize database connection
         # Connection string should be in environment variable
         import os
         connection_string = os.environ.get("DATABASE_URL")
         self.engine = sa.create_engine(connection_string)
-        super().__init__(params)
     
     @classmethod
     def sample_data_type(cls) -> Type[ShotData]:
@@ -323,14 +322,14 @@ class SQLDatabaseLoader(DataLoader):
     @pydantic.validate_call
     def get_sample(
         self, 
-        shot_id: int, 
-        sample_data: ShotData
+        sample: Sample,
+        params: DataParams, 
     ) -> MultiVariateTimeSeriesData:
         """Load time series data from database"""
         results = {}
-        
+
         with self.engine.connect() as conn:
-            for signal_name in sample_data.signal_names:
+            for signal_name in sample.data.signal_names:
                 # Query time series data for this shot and signal
                 query = sa.text("""
                     SELECT time, value 
@@ -341,7 +340,7 @@ class SQLDatabaseLoader(DataLoader):
                 
                 result = conn.execute(
                     query, 
-                    {"shot_id": shot_id, "signal_name": signal_name}
+                    {"shot_id": sample.shot_id, "signal_name": signal_name}
                 )
                 rows = result.fetchall()
                 

--- a/docs/custom_models.md
+++ b/docs/custom_models.md
@@ -161,10 +161,10 @@ from toktagger.api.core.data_loaders import LoaderRegistry
 from toktagger.api.schemas.data import DataParams
 
 # Initialize data loader
-data_loader = LoaderRegistry.get(self.project.data_loader)(DataParams(...))
+data_loader = LoaderRegistry.get(self.project.data_loader)()
 
 # Get data for a sample
-data = data_loader.get_sample(sample.shot_id, sample.data)
+data = data_loader.get_sample(sample, DataParams())
 ```
 
 ## Progress Tracking
@@ -227,13 +227,13 @@ class RandomForestModel(Model):
     
     def _extract_features(self, samples: list[Sample]) -> np.ndarray:
         """Extract statistical features from time series"""
-        data_loader = LoaderRegistry.get(self.project.data_loader)(DataParams())
+        data_loader = LoaderRegistry.get(self.project.data_loader)()
         features = []
         
         for sample in samples:
             data: TimeSeriesData = data_loader.get_sample(
-                sample.shot_id, 
-                sample.data
+                sample,
+                DataParams(),
             ).values["signal"]
             
             # Extract features: mean, std, min, max, etc.
@@ -322,8 +322,8 @@ class RandomForestModel(Model):
             uncertainty = 1.0 - np.max(probabilities[i])
             
             # Get time range for the sample
-            data_loader = LoaderRegistry.get(self.project.data_loader)(DataParams())
-            data = data_loader.get_sample(samples[i].shot_id, samples[i].data)
+            data_loader = LoaderRegistry.get(self.project.data_loader)()
+            data = data_loader.get_sample(samples[i], DataParams())
             time_values = list(data.values.values())[0].time
             
             annotation = TimeInterval(

--- a/tests/api/core/test_data_loaders.py
+++ b/tests/api/core/test_data_loaders.py
@@ -35,10 +35,10 @@ def test_image_file_loader_jpeg():
         project_id="test",
         validated_annotations=False,
     )
-    data_loader = data_loaders.ImageDataLoader(
-        params=ImageParams(name="image", frame=1)
+    data_loader = data_loaders.ImageDataLoader()
+    image_data = data_loader.get_sample(
+        sample, params=ImageParams(name="image", frame=1)
     )
-    image_data = data_loader.get_sample(sample)
     assert isinstance(image_data, ImageData)
     # Check we got back base64 encoded string
     assert isinstance(image_data.values, str)
@@ -61,10 +61,10 @@ def test_image_file_loader_png():
         project_id="test",
         validated_annotations=False,
     )
-    data_loader = data_loaders.ImageDataLoader(
-        params=ImageParams(name="image", frame=1)
+    data_loader = data_loaders.ImageDataLoader()
+    image_data = data_loader.get_sample(
+        sample, params=ImageParams(name="image", frame=1)
     )
-    image_data = data_loader.get_sample(sample)
     assert isinstance(image_data, ImageData)
     # Check we got back base64 encoded string
     assert isinstance(image_data.values, str)
@@ -88,8 +88,8 @@ def test_parquet_file_loader():
         project_id="test",
         validated_annotations=False,
     )
-    data_loader = data_loaders.TabularDataLoader(params=DataParams(name="identity"))
-    data = data_loader.get_sample(sample)
+    data_loader = data_loaders.TabularDataLoader()
+    data = data_loader.get_sample(sample, params=DataParams(name="identity"))
     assert isinstance(data, MultiVariateTimeSeriesData)
 
     # Check both columns requested are present
@@ -121,8 +121,8 @@ def test_uda_loader(uda_test):
         project_id="test",
         validated_annotations=False,
     )
-    data_loader = data_loaders.UDADataLoader(params=DataParams(name="identity"))
-    data = data_loader.get_sample(sample)
+    data_loader = data_loaders.UDADataLoader()
+    data = data_loader.get_sample(sample, params=DataParams(name="identity"))
     assert isinstance(data, MultiVariateTimeSeriesData)
 
     # Check both columns requested are present
@@ -153,10 +153,8 @@ def test_uda_camera_loader(uda_env_vars):
         project_id="test",
         validated_annotations=False,
     )
-    data_loader = data_loaders.UDACameraDataLoader(
-        params=ImageParams(name="image", frame=0)
-    )
-    data = data_loader.get_sample(sample)
+    data_loader = data_loaders.UDACameraDataLoader()
+    data = data_loader.get_sample(sample, params=ImageParams(name="image", frame=0))
     assert isinstance(data, ImageData)
     # Check we got back base64 encoded string
     assert isinstance(data.values, str)
@@ -182,10 +180,10 @@ def test_uda_loader_data_doesnt_exist(uda_env_vars):
         project_id="test",
         validated_annotations=False,
     )
-    data_loader = data_loaders.UDADataLoader(params=DataParams(name="identity"))
+    data_loader = data_loaders.UDADataLoader()
 
     try:
-        data_loader.get_sample(sample)
+        data_loader.get_sample(sample, params=DataParams(name="identity"))
         pytest.fail("Expected DataLoaderError not raised")
     except data_loaders.DataLoaderError:
         pass
@@ -209,8 +207,8 @@ def test_sal_loader():
         project_id="test",
         validated_annotations=False,
     )
-    data_loader = data_loaders.SALDataLoader(DataParams(name="identity"))
-    data = data_loader.get_sample(sample)
+    data_loader = data_loaders.SALDataLoader()
+    data = data_loader.get_sample(sample, DataParams(name="identity"))
 
     ip_values = numpy.array(data.values.get("ppf/signal/jetppf/magn/ipla").values)
     assert numpy.min(ip_values) == -1837277.75
@@ -230,8 +228,8 @@ def test_fair_mast_dataloader():
         project_id="test",
         validated_annotations=False,
     )
-    data_loader = data_loaders.FAIRMASTDataLoader(params=DataParams(name="identity"))
-    data = data_loader.get_sample(sample)
+    data_loader = data_loaders.FAIRMASTDataLoader()
+    data = data_loader.get_sample(sample, params=DataParams(name="identity"))
     assert isinstance(data, MultiVariateTimeSeriesData)
 
     # Check both columns requested are present
@@ -263,7 +261,7 @@ async def test_custom_data_loader(api_client):
         def sample_data_type(self) -> Type[ShotData]:
             return ShotData
 
-        def get_sample(self, sample: Sample, **kwargs):
+        def get_sample(self, sample: Sample, params: DataParams, **kwargs):
             shot_id = sample.shot_id
             # Return some data, use something from sample to check it is passed in correctly
             return MultiVariateTimeSeriesData(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,8 @@ from toktagger.api.main import Server
 from toktagger.api.crud.db import MongoDBClient
 from toktagger.api.schemas.annotations import TimePointBatch
 from toktagger.api.schemas.samples import SampleIn, TimeSeriesFileData
-from toktagger.api.models.base import ModelRegistry, WorkerModelRegistry, ActorRegistry
+from toktagger.api.models.base import ModelRegistry, WorkerRegistry, ActorRegistry
+from toktagger.api.core.data_loaders import LoaderRegistry
 from testcontainers.mongodb import MongoDbContainer
 import tests.db_definitions as db_definitions
 from bson.objectid import ObjectId
@@ -52,9 +53,13 @@ def ray_session():
             ignore_reinit_error=True, local_mode=True, runtime_env={"working_dir": None}
         )
         # Create a ray actor for use as a model registry
-        WorkerModelRegistry.options(
-            name="WorkerModelRegistry", lifetime="detached"
-        ).remote(ModelRegistry._registry)
+        WorkerRegistry.options(name="WorkerModelRegistry", lifetime="detached").remote(
+            ModelRegistry._registry
+        )
+        # And one for use as a dataloader registry
+        WorkerRegistry.options(name="WorkerLoaderRegistry", lifetime="detached").remote(
+            LoaderRegistry._registry
+        )
         yield
         ray.shutdown()
 

--- a/tests/end_to_end/test_projects_page.py
+++ b/tests/end_to_end/test_projects_page.py
@@ -176,9 +176,9 @@ def test_projects_sorting(server_setup, page: Page):
         expect(page.get_by_role("row").nth(2)).to_contain_text(expected_first)
 
     # Create some projects
-    create_project("A Project", "time-series", "uda")
+    create_project("A Project", "video", "uda")
     time.sleep(0.1)
-    create_project("B Project", "video", "tabular")
+    create_project("B Project", "time-series", "tabular")
 
     # Navigate to page
     page.goto("http://localhost:8002")
@@ -189,7 +189,7 @@ def test_projects_sorting(server_setup, page: Page):
     # Sort by Name: A should be first, then B
     sort(page, "Name", "A Project", "B Project")
 
-    # Sort by Task, b should be first (spectrogram), then A (time-series)
+    # Sort by Task, B should be first (time-series), then A (video)
     sort(page, "Task", "B Project", "A Project")
 
     # Sort by Timestamp, A should be first (oldest - so lowest timestamp), then B (newest - highest timestamp)

--- a/toktagger/api/core/data_loaders.py
+++ b/toktagger/api/core/data_loaders.py
@@ -60,7 +60,7 @@ class DataLoader(ABC):
     def get_sample(
         self,
         sample: Sample,
-        params: DataParamTypes = DataParams,
+        params: DataParamTypes = DataParams(),
         **kwargs,
     ) -> Data:
         pass

--- a/toktagger/api/core/data_loaders.py
+++ b/toktagger/api/core/data_loaders.py
@@ -298,9 +298,6 @@ class UDADataLoader(DataLoader):
 class UDACameraDataLoader(DataLoader):
     """DataLoader for retrieving camera image data using the UDA access layer"""
 
-    def __init__(self, params: DataParamTypes):
-        super().__init__(params)
-
     @classmethod
     def sample_data_type(self) -> Type[ShotData]:
         return ShotData

--- a/toktagger/api/core/data_loaders.py
+++ b/toktagger/api/core/data_loaders.py
@@ -16,6 +16,8 @@ from PIL import Image
 from toktagger.api.schemas.data import (
     Data,
     DataParamTypes,
+    ImageParams,
+    DataParams,
     ImageData,
     MultiVariateTimeSeriesData,
     TimeSeriesData,
@@ -46,9 +48,6 @@ class DataLoaderError(Exception):
 
 
 class DataLoader(ABC):
-    def __init__(self, params: DataParamTypes):
-        self.params = params
-
     @classmethod
     @abstractmethod
     def sample_data_type(
@@ -61,6 +60,7 @@ class DataLoader(ABC):
     def get_sample(
         self,
         sample: Sample,
+        params: DataParamTypes,
         **kwargs,
     ) -> Data:
         pass
@@ -113,15 +113,12 @@ class LoaderRegistry:
 class ImageDataLoader(DataLoader):
     """DataLoader for retrieving data using a folder of image files"""
 
-    def __init__(self, params: DataParamTypes):
-        super().__init__(params)
-
     @classmethod
     def sample_data_type(cls) -> Type[ImageFileData]:
         return ImageFileData
 
     @pydantic.validate_call
-    def get_sample(self, sample: Sample, **kwargs) -> ImageData:
+    def get_sample(self, sample: Sample, params: ImageParams, **kwargs) -> ImageData:
         if not isinstance(sample.data, ImageFileData):
             raise TypeError(
                 f"Expected sample data of type 'ImageFileData' but got '{type(sample.data)}'"
@@ -136,15 +133,15 @@ class ImageDataLoader(DataLoader):
                 f"Could not find directory at '{dir_path}', relative to {pathlib.Path().cwd()} - {list(pathlib.Path().cwd().iterdir())}"
             )
         # Open image which represents frame selected
-        if self.params.name != "image":
+        if params.name != "image":
             raise ValueError("Must provide image data parameters!")
-        elif self.params.frame is None:
+        elif params.frame is None:
             files = sorted(dir_path.iterdir())
             if len(files) == 0:
                 raise FileNotFoundError("No files exist in specified directory!")
             file_path = files[0]
         else:
-            file_path = dir_path.joinpath(f"{self.params.frame}.{sample_data.type}")
+            file_path = dir_path.joinpath(f"{params.frame}.{sample_data.type}")
         if not file_path.exists():
             raise FileNotFoundError(
                 f"Could not find image file at '{file_path}', relative to {pathlib.Path().cwd()}"
@@ -172,6 +169,7 @@ class TabularDataLoader(DataLoader):
     def get_sample(
         self,
         sample: Sample,
+        params: DataParams,
         time_min: Optional[float] = None,
         time_max: Optional[float] = None,
         min_time_step: Optional[float] = None,
@@ -242,6 +240,7 @@ class UDADataLoader(DataLoader):
     def get_sample(
         self,
         sample: Sample,
+        params: DataParams,
         time_min: Optional[float] = None,
         time_max: Optional[float] = None,
         min_time_step: Optional[float] = None,
@@ -251,6 +250,8 @@ class UDADataLoader(DataLoader):
             raise TypeError(
                 f"Expected sample data of type 'ShotData' but got '{type(sample.data)}'"
             )
+        if not params.name == "identity":
+            raise TypeError(f"Expected blank parameters, but got '{params.name}'")
 
         sample_data: ShotData = sample.data
 
@@ -307,6 +308,7 @@ class UDACameraDataLoader(DataLoader):
     def get_sample(
         self,
         sample: Sample,
+        params: ImageParams,
         **kwargs,
     ) -> ImageData:
         if not isinstance(sample.data, ShotData):
@@ -321,13 +323,13 @@ class UDACameraDataLoader(DataLoader):
 
         signal_name = sample_data.signal_names[0]
         try:
-            if self.params.frame is None:
-                self.params.frame = 0  # Default to first frame if not specified
+            if params.frame is None:
+                params.frame = 0  # Default to first frame if not specified
 
             signal = xr.open_dataset(
                 f"uda://{signal_name}:{sample.shot_id}",
                 engine="uda",
-                frame_number=self.params.frame,
+                frame_number=params.frame,
             )
 
             image_array = signal["data"].values
@@ -339,7 +341,7 @@ class UDACameraDataLoader(DataLoader):
             buffer.seek(0)
 
             return ImageData(
-                frame=str(self.params.frame),
+                frame=str(params.frame),
                 values=base64.b64encode(buffer.getvalue()).decode(),
             )
         except Exception as e:
@@ -359,6 +361,7 @@ class SALDataLoader(DataLoader):
     def get_sample(
         self,
         sample: Sample,
+        params: DataParams,
         time_min: Optional[float] = None,
         time_max: Optional[float] = None,
         min_time_step: Optional[float] = None,
@@ -366,6 +369,9 @@ class SALDataLoader(DataLoader):
     ) -> MultiVariateTimeSeriesData:
         assert isinstance(sample.data, ShotData), "Sample data must be of type ShotData"
         sample_data: ShotData = sample.data
+
+        if not params.name == "identity":
+            raise TypeError(f"Expected blank parameters, but got '{params.name}'")
 
         has_user_credentials = Path("~/.sal/credentials").expanduser().exists()
         if not has_user_credentials:
@@ -424,6 +430,7 @@ class FAIRMASTDataLoader(DataLoader):
     def get_sample(
         self,
         sample: Sample,
+        params: DataParams,
         time_min: Optional[float] = None,
         time_max: Optional[float] = None,
         min_time_step: Optional[float] = None,
@@ -431,6 +438,9 @@ class FAIRMASTDataLoader(DataLoader):
     ) -> MultiVariateTimeSeriesData:
         assert isinstance(sample.data, ShotData), "Sample data must be of type ShotData"
         sample_data: ShotData = sample.data
+
+        if not params.name == "identity":
+            raise TypeError(f"Expected blank parameters, but got '{params.name}'")
 
         endpoint = "https://s3.echo.stfc.ac.uk/mast/level2/shots"
         file_path = f"{endpoint}/{sample.shot_id}.zarr"

--- a/toktagger/api/core/data_loaders.py
+++ b/toktagger/api/core/data_loaders.py
@@ -60,7 +60,7 @@ class DataLoader(ABC):
     def get_sample(
         self,
         sample: Sample,
-        params: DataParamTypes,
+        params: DataParamTypes = DataParams,
         **kwargs,
     ) -> Data:
         pass

--- a/toktagger/api/main.py
+++ b/toktagger/api/main.py
@@ -14,7 +14,7 @@ from toktagger.api.routers.samples import router as samples_router
 from toktagger.api.routers.base import router as base_router
 from toktagger.api.routers.paths import router as paths_router
 from toktagger.api.routers.meta import router as meta_router
-
+from toktagger.api.core.data_loaders import LoaderRegistry
 from toktagger.api.crud.db import MongoDBClient
 from toktagger.api.models import models_dependencies_installed
 
@@ -22,7 +22,7 @@ from toktagger.api.models import models_dependencies_installed
 if models_dependencies_installed():
     from toktagger.api.models.base import (
         ModelRegistry,
-        WorkerModelRegistry,
+        WorkerRegistry,
         ActorRegistry,
     )
     import ray
@@ -60,9 +60,13 @@ class Server:
         )
 
         # Create a ray actor for use as a model registry
-        WorkerModelRegistry.options(
-            name="WorkerModelRegistry", lifetime="detached"
-        ).remote(ModelRegistry._registry)
+        WorkerRegistry.options(name="WorkerModelRegistry", lifetime="detached").remote(
+            ModelRegistry._registry
+        )
+        # And one for use as a dataloader registry
+        WorkerRegistry.options(name="WorkerLoaderRegistry", lifetime="detached").remote(
+            LoaderRegistry._registry
+        )
 
     def _setup_app(self):
         self.app = FastAPI(lifespan=lifespan)

--- a/toktagger/api/models/base.py
+++ b/toktagger/api/models/base.py
@@ -1,6 +1,7 @@
 from toktagger.api.schemas.samples import Sample
 from toktagger.api.schemas.annotations import Annotation, AnnotationBase
 from toktagger.api.schemas.projects import Project, Task
+from toktagger.api.core.data_loaders import DataLoader
 from sklearn.model_selection import train_test_split
 from abc import ABC, abstractmethod
 import typing
@@ -185,15 +186,15 @@ class ModelRegistry:
 
 
 @ray.remote
-class WorkerModelRegistry:
+class WorkerRegistry:
     def __init__(self, registry):
-        self._registry: dict[str, Model] = registry
+        self._registry: dict[str, Model | DataLoader] = registry
 
     def get(self, name):
-        model_class: Model | None = self._registry.get(name)
-        if not model_class:
-            raise ValueError(f"No Model class called '{name}' found in registry!")
-        return ray.remote(model_class)
+        registered: Model | DataLoader | None = self._registry.get(name)
+        if not registered:
+            raise ValueError(f"No class called '{name}' found in registry!")
+        return ray.remote(registered)
 
 
 class ActorRegistry:

--- a/toktagger/api/models/base.py
+++ b/toktagger/api/models/base.py
@@ -29,6 +29,8 @@ class Model(ABC):
         self.project = project
         self.model = self.define_model()
         self.type = ModelRegistry.get_name(self.__class__)
+        loader_registry = ray.get_actor("WorkerLoaderRegistry")
+        self.data_loader = loader_registry.get(project.data_loader)()
 
     def log_progress(
         self,

--- a/toktagger/api/models/base.py
+++ b/toktagger/api/models/base.py
@@ -29,8 +29,11 @@ class Model(ABC):
         self.project = project
         self.model = self.define_model()
         self.type = ModelRegistry.get_name(self.__class__)
-        loader_registry = ray.get_actor("WorkerLoaderRegistry")
-        self.data_loader = loader_registry.get(project.data_loader)()
+        loader_registry: WorkerRegistry = ray.get_actor("WorkerLoaderRegistry")
+        data_loader: DataLoader = ray.get(
+            loader_registry.get.remote(project.data_loader)
+        )
+        self.data_loader = data_loader()
 
     def log_progress(
         self,
@@ -196,7 +199,7 @@ class WorkerRegistry:
         registered: Model | DataLoader | None = self._registry.get(name)
         if not registered:
             raise ValueError(f"No class called '{name}' found in registry!")
-        return ray.remote(registered)
+        return registered
 
 
 class ActorRegistry:

--- a/toktagger/api/models/disruption.py
+++ b/toktagger/api/models/disruption.py
@@ -1,7 +1,7 @@
 from toktagger.api.schemas.projects import Project
 from toktagger.api.schemas.samples import Sample
 from toktagger.api.schemas.annotations import TimePoint
-from toktagger.api.schemas.data import TimeSeriesData
+from toktagger.api.schemas.data import TimeSeriesData, DataParams
 from sklearn.metrics import mean_absolute_error, root_mean_squared_error
 import torch.nn as nn
 import torch
@@ -32,9 +32,9 @@ class DisruptionDataset(Dataset):  # Inherit from torch.utils.dataset
         return len(self.samples)
 
     def __getitem__(self, idx: int) -> tuple[torch.tensor, int]:
-        data: TimeSeriesData = self.data_loader.get_sample(self.samples[idx]).values[
-            "ip"
-        ]
+        data: TimeSeriesData = self.data_loader.get_sample(
+            self.samples[idx], DataParams()
+        ).values["ip"]
         # Scale data to be between 0 and 1...
         plasma_current = torch.tensor(data.values, dtype=torch.float32)
         self.current_scaling.append(plasma_current.max())

--- a/toktagger/api/models/disruption.py
+++ b/toktagger/api/models/disruption.py
@@ -1,14 +1,13 @@
 from toktagger.api.schemas.projects import Project
 from toktagger.api.schemas.samples import Sample
 from toktagger.api.schemas.annotations import TimePoint
-from toktagger.api.schemas.data import TimeSeriesData, DataParams
+from toktagger.api.schemas.data import TimeSeriesData
 from sklearn.metrics import mean_absolute_error, root_mean_squared_error
 import torch.nn as nn
 import torch
 from torch.utils.data import DataLoader, Dataset
 from toktagger.api.schemas.annotations import Annotation
 import typing
-from toktagger.api.core.data_loaders import LoaderRegistry
 from toktagger.api.models.base import Model, ModelRegistry
 import logging
 
@@ -21,8 +20,9 @@ class DisruptionDataset(Dataset):  # Inherit from torch.utils.dataset
         project: Project,
         samples: list[Sample],
         annotations: list[list[Annotation]],
+        data_loader: DataLoader,
     ):
-        self.data_loader = LoaderRegistry.get(project.data_loader)(DataParams())
+        self.data_loader = data_loader
         self.samples = samples
         self.annotations = annotations
         self.current_scaling = []
@@ -85,15 +85,19 @@ class DisruptionCNN(Model):
         )
 
         self.train_dataset = DisruptionDataset(
-            self.project, self.train_samples, self.train_annotations
+            self.project, self.train_samples, self.train_annotations, self.data_loader
         )
         self.val_dataset = (
-            DisruptionDataset(self.project, self.val_samples, self.val_annotations)
+            DisruptionDataset(
+                self.project, self.val_samples, self.val_annotations, self.data_loader
+            )
             if self.val_samples
             else None
         )
         self.test_dataset = (
-            DisruptionDataset(self.project, self.test_samples, self.test_annotations)
+            DisruptionDataset(
+                self.project, self.test_samples, self.test_annotations, self.data_loader
+            )
             if self.test_samples
             else None
         )
@@ -255,7 +259,9 @@ class DisruptionCNN(Model):
         self, samples: list[Sample], batch_size: int = 32, device="cpu"
     ) -> list[list[TimePoint]]:
         num_mc_samples = 20  # Should let user choose num mc samples? TODO
-        dataset = DisruptionDataset(self.project, samples, annotations=None)
+        dataset = DisruptionDataset(
+            self.project, samples, annotations=None, data_loader=self.data_loader
+        )
 
         self.model.train()  # Using dropout so has to be in train mode
         all_predictions: list[list[torch.tensor]] = []

--- a/toktagger/api/routers/annotators.py
+++ b/toktagger/api/routers/annotators.py
@@ -50,8 +50,8 @@ async def create_annotations(
 
     sample: Sample = await get_sample(db_client, project_id, sample_id)
 
-    data_loader = LoaderRegistry.get(project.data_loader)(data_params)
-    data_item = data_loader.get_sample(sample)
+    data_loader = LoaderRegistry.get(project.data_loader)()
+    data_item = data_loader.get_sample(sample, params=data_params)
 
     annotator = annotator_cls(annotator_params)
     annotations = annotator.predict(data_item)

--- a/toktagger/api/routers/data.py
+++ b/toktagger/api/routers/data.py
@@ -28,10 +28,11 @@ async def get_data(
     project = await utils.get_project(db_client, project_id)
     sample = await utils.get_sample(db_client, project_id, sample_id)
 
-    data_loader = LoaderRegistry.get(project.data_loader)(params)
+    data_loader = LoaderRegistry.get(project.data_loader)()
     try:
         data = data_loader.get_sample(
             sample,
+            params=params,
             time_min=project.time_min,
             time_max=project.time_max,
             min_time_step=project.min_time_step,

--- a/toktagger/api/worker.py
+++ b/toktagger/api/worker.py
@@ -43,9 +43,13 @@ def get_actor(project, model):
         model_registry = ray.get_actor("WorkerModelRegistry")
         model_type = ray.get(model_registry.get.remote(model.type))
 
-        ml_model = model_type.options(name=model.id, lifetime="detached").remote(
-            model_id=str(model.id),
-            project=project,
+        ml_model = (
+            ray.remote(model_type)
+            .options(name=model.id, lifetime="detached")
+            .remote(
+                model_id=str(model.id),
+                project=project,
+            )
         )
 
         model_path = pathlib.Path(os.environ["MODEL_STORAGE"]).joinpath(


### PR DESCRIPTION
* Adds a dataloader worker registry, so that models have access to user extended data loaders
* Refactors dataloaders to accept params inside `get_sample`, instead of in `__init__`
* Update docs
* Fix project sorting test (hangover from previous merge)