### PR TITLE
Improve docs: add dark mode and fix build instructions

### DIFF
--- a/docs/dev/building-the-docs.md
+++ b/docs/dev/building-the-docs.md
@@ -5,7 +5,7 @@ We use [MKDocs](https://www.mkdocs.org/) for our documentation. To build and vie
 1. Check you've installed the relevant dependancies:
 
 ```sh
-uv pip install -r requirements.txt
+uv sync --group dev
 ```
 
 2. Run the `mkdocs` command

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,18 @@ site_name: TokTagger
 theme:
   name: material
   palette:
-    scheme: default
+    - scheme: default
+      primary: blue
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      primary: blue
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
   features:
     - content.code.copy
 markdown_extensions: 


### PR DESCRIPTION
* Add Material dark mode toggle.
* Fix outdated docs build instructions (use `uv sync` instead of missing `requirements.txt`)