### PR TITLE
Adds optional raw image support to ImageDataLoader

### DIFF
--- a/tests/api/core/test_data_loaders.py
+++ b/tests/api/core/test_data_loaders.py
@@ -49,6 +49,36 @@ def test_image_file_loader_jpeg():
     assert numpy.array(image).shape == (1079, 881, 3)
 
 
+def test_image_file_loader_jpeg_raw():
+    img_file = ImageFileData(
+        file_name=str(pathlib.Path(__file__).parents[2].joinpath("mast_images")),
+        type="jpeg",
+        protocol="file",
+    )
+    sample = Sample(
+        shot_id=10000,
+        data=img_file,
+        _id="test",
+        project_id="test",
+        validated_annotations=False,
+    )
+    data_loader = data_loaders.ImageDataLoader()
+    image_data = data_loader.get_sample(
+        sample,
+        params=ImageParams(
+            name="image",
+            frame=1,
+            return_raw=True,
+        ),
+    )
+    assert isinstance(image_data, ImageData)
+    # Check we got back a list
+    assert isinstance(image_data.values, list)
+
+    image = Image.open(io.BytesIO(bytes(image_data.values)))
+    assert numpy.array(image).shape == (1079, 881, 3)
+
+
 def test_image_file_loader_png():
     img_file = ImageFileData(
         file_name=str(pathlib.Path(__file__).parents[2].joinpath("mast_images")),
@@ -72,6 +102,36 @@ def test_image_file_loader_png():
     # Convert back to numpy array
     base64_decoded = base64.b64decode(image_data.values)
     image = Image.open(io.BytesIO(base64_decoded))
+    assert numpy.array(image).shape == (1079, 881, 3)
+
+
+def test_image_file_loader_png_raw():
+    img_file = ImageFileData(
+        file_name=str(pathlib.Path(__file__).parents[2].joinpath("mast_images")),
+        type="png",
+        protocol="file",
+    )
+    sample = Sample(
+        shot_id=10000,
+        data=img_file,
+        _id="test",
+        project_id="test",
+        validated_annotations=False,
+    )
+    data_loader = data_loaders.ImageDataLoader()
+    image_data = data_loader.get_sample(
+        sample,
+        params=ImageParams(
+            name="image",
+            frame=1,
+            return_raw=True,
+        ),
+    )
+    assert isinstance(image_data, ImageData)
+    # Check we got back a list
+    assert isinstance(image_data.values, list)
+
+    image = Image.open(io.BytesIO(bytes(image_data.values)))
     assert numpy.array(image).shape == (1079, 881, 3)
 
 

--- a/toktagger/api/core/data_loaders.py
+++ b/toktagger/api/core/data_loaders.py
@@ -17,6 +17,7 @@ from toktagger.api.schemas.data import (
     Data,
     DataParamTypes,
     ImageParams,
+    RawImageData,
     DataParams,
     ImageData,
     MultiVariateTimeSeriesData,
@@ -124,7 +125,7 @@ class ImageDataLoader(DataLoader):
         return ImageFileData
 
     @pydantic.validate_call
-    def get_sample(self, sample: Sample, params: ImageParams, **kwargs) -> ImageData:
+    def get_sample(self, sample: Sample, params: ImageParams, **kwargs) -> ImageData | RawImageData:
         if not isinstance(sample.data, ImageFileData):
             raise TypeError(
                 f"Expected sample data of type 'ImageFileData' but got '{type(sample.data)}'"
@@ -153,6 +154,13 @@ class ImageDataLoader(DataLoader):
                 f"Could not find image file at '{file_path}', relative to {pathlib.Path().cwd()}"
             )
         im = Image.open(file_path)
+        # return a raw image if the user says return_raw=True
+        if params.return_raw:
+            return RawImageData(
+                frame=int(file_path.stem),
+                values=im,
+            )
+
         buffer = io.BytesIO()
         im.save(buffer, format="PNG")
         buffer.seek(0)

--- a/toktagger/api/core/data_loaders.py
+++ b/toktagger/api/core/data_loaders.py
@@ -17,7 +17,6 @@ from toktagger.api.schemas.data import (
     Data,
     DataParamTypes,
     ImageParams,
-    RawImageData,
     DataParams,
     ImageData,
     MultiVariateTimeSeriesData,
@@ -125,7 +124,7 @@ class ImageDataLoader(DataLoader):
         return ImageFileData
 
     @pydantic.validate_call
-    def get_sample(self, sample: Sample, params: ImageParams, **kwargs) -> ImageData | RawImageData:
+    def get_sample(self, sample: Sample, params: ImageParams, **kwargs) -> ImageData:
         if not isinstance(sample.data, ImageFileData):
             raise TypeError(
                 f"Expected sample data of type 'ImageFileData' but got '{type(sample.data)}'"
@@ -153,13 +152,14 @@ class ImageDataLoader(DataLoader):
             raise FileNotFoundError(
                 f"Could not find image file at '{file_path}', relative to {pathlib.Path().cwd()}"
             )
-        im = Image.open(file_path)
-        # return a raw image if the user says return_raw=True
+        # return raw encoded file bytes if return_raw is True
         if params.return_raw:
-            return RawImageData(
-                frame=int(file_path.stem),
-                values=im,
+            return ImageData(
+                frame=file_path.name.split(".")[0],
+                values=list(file_path.read_bytes()),
             )
+
+        im = Image.open(file_path)
 
         buffer = io.BytesIO()
         im.save(buffer, format="PNG")

--- a/toktagger/api/schemas/data.py
+++ b/toktagger/api/schemas/data.py
@@ -38,9 +38,8 @@ class DataParams(ConfiguredModel):
 class ImageParams(DataParams):
     name: Literal["image"] = "image"
     frame: int | None
-    return_raw: bool = (
-        False  # Optional: Return raw encoded image bytes instead of base64.
-    )
+    # Optional: Return raw encoded image bytes instead of base64.
+    return_raw: bool = False
 
 
 DataResponseType = Union[

--- a/toktagger/api/schemas/data.py
+++ b/toktagger/api/schemas/data.py
@@ -1,6 +1,7 @@
 from typing import Union, Literal
 from pydantic import BaseModel
 from toktagger.api.schemas import ConfiguredModel
+from PIL.Image import Image as PILImage
 
 
 class Data(BaseModel):
@@ -35,9 +36,20 @@ class DataParams(ConfiguredModel):
     name: Literal["identity"] = "identity"
 
 
+class RawImageData():
+    def __init__(self, frame: int, values: PILImage):
+        """
+        Return a raw image without any encoding for ML use.
+        RawImageData is not the part of the API schema.
+        """
+        self.frame = frame
+        self.values = values
+
+
 class ImageParams(DataParams):
     name: Literal["image"] = "image"
     frame: int | None
+    return_raw: bool = False # optional boolean flag to return raw image
 
 
 DataResponseType = Union[

--- a/toktagger/api/schemas/data.py
+++ b/toktagger/api/schemas/data.py
@@ -1,7 +1,6 @@
 from typing import Union, Literal
 from pydantic import BaseModel
 from toktagger.api.schemas import ConfiguredModel
-from PIL.Image import Image as PILImage
 
 
 class Data(BaseModel):
@@ -29,27 +28,19 @@ class SpectrogramData(Data):
 
 class ImageData(Data):
     frame: int
-    values: str  # Base64 encoded string
+    values: str | list[int]  # Base64-encoded string or raw encoded file bytes
 
 
 class DataParams(ConfiguredModel):
     name: Literal["identity"] = "identity"
 
 
-class RawImageData():
-    def __init__(self, frame: int, values: PILImage):
-        """
-        Return a raw image without any encoding for ML use.
-        RawImageData is not the part of the API schema.
-        """
-        self.frame = frame
-        self.values = values
-
-
 class ImageParams(DataParams):
     name: Literal["image"] = "image"
     frame: int | None
-    return_raw: bool = False # optional boolean flag to return raw image
+    return_raw: bool = (
+        False  # Optional: Return raw encoded image bytes instead of base64.
+    )
 
 
 DataResponseType = Union[


### PR DESCRIPTION
`ImageDataLoader` currently returns images as base64-encoded PNGs. This introduces additional overhead for ML training, where images are immediately decoded back into `PIL.Image` objects.

This PR adds an optional `return_raw` flag to ImageParams. When enabled, the loader returns a `RawImageData` containing a `PIL.Image` instead of a base64 string. `return_raw=False` remains the default, so Existing API calls require no modifications.

A couple of questions:
* Consider using a dataclass for `RawImageData`?
* Should `RawImageData` inherit from `Data`? Coz Pydantic doesn't know how to validate a `PIL.Image.Image`.