### PR TITLE
Change save/load to use results dir paths instead of single files

### DIFF
--- a/tests/api/routers/test_models.py
+++ b/tests/api/routers/test_models.py
@@ -738,8 +738,9 @@ async def test_model_load_local_failed(models_api_client, db_client, setup_model
         assert model["training_status"] == "failed"
 
         # Check model has not been saved after completion
-        assert (
-            not pathlib.Path(config.settings.models.cache_dir)
-            .joinpath(f"{model_id}.model")
-            .exists()
+        model_path = (
+            pathlib.Path(config.settings.models.cache_dir)
+            .joinpath(f"{model_id}")
+            .joinpath("weights.model")
         )
+        assert not model_path.exists()

--- a/tests/api/routers/test_models.py
+++ b/tests/api/routers/test_models.py
@@ -163,8 +163,8 @@ async def test_model_predict_missing_weights(
 ):
     # Delete weights
     config.settings.models.cache_dir.joinpath(
-        f"{setup_model_db['model_id_1']}.model"
-    ).unlink()
+        f"{setup_model_db['model_id_1']}"
+    ).joinpath("weights.model").unlink()
     response = await models_api_client.post(
         f"/projects/{setup_model_db['project_id']}/models/mock_disruption_cnn/predict?num_predictions=5&version=1"
     )
@@ -376,7 +376,11 @@ async def test_model_start_training_no_params(
     assert model["score"] == 60  # value returned by train method
 
     # Check model has been saved after completion
-    assert config.settings.models.cache_dir.joinpath(f"{model_id}.model").exists()
+    assert (
+        config.settings.models.cache_dir.joinpath(f"{model_id}")
+        .joinpath("weights.model")
+        .exists()
+    )
 
 
 @pytest.mark.asyncio
@@ -462,7 +466,11 @@ async def test_model_start_training_params(
     assert model["score"] == 50  # value returned from params
 
     # Check model has been saved after completion
-    assert config.settings.models.cache_dir.joinpath(f"{model_id}.model").exists()
+    assert (
+        config.settings.models.cache_dir.joinpath(f"{model_id}")
+        .joinpath("weights.model")
+        .exists()
+    )
 
 
 # Test delete model
@@ -483,17 +491,17 @@ async def test_model_delete_type(models_api_client, db_client, setup_model_db):
 
     # Check for models 1 and 2, their file no longer exists
     assert not config.settings.models.cache_dir.joinpath(
-        f"{setup_model_db['model_id_1']}.model"
+        f"{setup_model_db['model_id_1']}"
     ).exists()
     assert not config.settings.models.cache_dir.joinpath(
-        f"{setup_model_db['model_id_2']}.model"
+        f"{setup_model_db['model_id_2']}"
     ).exists()
     # And for model 3 it does still exist
     assert config.settings.models.cache_dir.joinpath(
-        f"{setup_model_db['model_id_3']}.model"
+        f"{setup_model_db['model_id_3']}"
     ).exists()
     assert config.settings.models.cache_dir.joinpath(
-        f"{setup_model_db['model_id_3']}.model"
+        f"{setup_model_db['model_id_4']}"
     ).exists()
 
 
@@ -518,13 +526,13 @@ async def test_model_delete_type_version(models_api_client, db_client, setup_mod
 
     # Check for model 2, their file no longer exists
     assert not config.settings.models.cache_dir.joinpath(
-        f"{setup_model_db['model_id_2']}.model"
+        f"{setup_model_db['model_id_2']}"
     ).exists()
     # And for models 1, 3 and 4 it does still exist
     assert all(
         (
             config.settings.models.cache_dir.joinpath(
-                f"{setup_model_db[model_id]}.model"
+                f"{setup_model_db[model_id]}"
             ).exists()
         )
         for model_id in ("model_id_1", "model_id_3", "model_id_4")
@@ -647,8 +655,10 @@ async def test_model_load_local(models_api_client, db_client, setup_model_db):
         assert model["progress"] == 100
 
         # Check model has been saved after completion
-        model_path = pathlib.Path(config.settings.models.cache_dir).joinpath(
-            f"{model_id}.model"
+        model_path = (
+            pathlib.Path(config.settings.models.cache_dir)
+            .joinpath(f"{model_id}")
+            .joinpath("weights.model")
         )
         assert model_path.exists()
 

--- a/tests/api/routers/test_models.py
+++ b/tests/api/routers/test_models.py
@@ -471,6 +471,11 @@ async def test_model_start_training_params(
         .joinpath("weights.model")
         .exists()
     )
+    assert (
+        config.settings.models.cache_dir.joinpath(f"{model_id}")
+        .joinpath("config.json")
+        .exists()
+    )
 
 
 # Test delete model

--- a/tests/end_to_end/test_samples_page.py
+++ b/tests/end_to_end/test_samples_page.py
@@ -1083,8 +1083,9 @@ def test_model_load_predict(server_setup, setup_model_samples, page: Page):
         model_id = response.json()["_id"]
         # Check file exists and has correct contents
         new_weights_path = config.settings.models.cache_dir.joinpath(
-            f"{model_id}.model"
-        )
+            f"{model_id}"
+        ).joinpath("weights.model")
+
         assert new_weights_path.exists()
         assert new_weights_path.read_text() == "Loaded Model Weights"
 

--- a/tests/models_definitions.py
+++ b/tests/models_definitions.py
@@ -41,11 +41,15 @@ class MockDisruptionCNN(Model):
             for i in range(len(samples))
         ]
 
-    def save(self, file_stem: str):
-        pathlib.Path(file_stem).with_suffix(".model").write_text(self.model)
+    def save(self, results_dir: pathlib.Path):
+        results_dir.joinpath("weights.model").write_text(self.model)
 
-    def load(self, file_path):
-        self.model = pathlib.Path(file_path).read_text()
+    def load(self, results_dir: pathlib.Path, weights_filename: str | None = None):
+        if weights_filename:
+            results_file = results_dir.joinpath(weights_filename)
+        else:
+            results_file = results_dir.joinpath("weights.model")
+        self.model = results_file.read_text()
 
 
 class TimeSeriesCNN(Model):
@@ -96,11 +100,15 @@ class TimeSeriesCNN(Model):
             )
         return anns
 
-    def save(self, file_stem: str):
-        pathlib.Path(file_stem).with_suffix(".model").write_text(self.model)
+    def save(self, results_dir: pathlib.Path):
+        results_dir.joinpath("weights.model").write_text(self.model)
 
-    def load(self, file_path):
-        self.model = pathlib.Path(file_path).read_text()
+    def load(self, results_dir: pathlib.Path, weights_filename: str | None = None):
+        if weights_filename:
+            results_file = results_dir.joinpath(weights_filename)
+        else:
+            results_file = results_dir.joinpath("weights.model")
+        self.model = results_file.read_text()
 
 
 @ray.remote

--- a/tests/models_definitions.py
+++ b/tests/models_definitions.py
@@ -176,6 +176,10 @@ class MockParamsTimeSeriesCNN(TimeSeriesCNN):
             )
         return anns
 
+    def save(self, results_dir: pathlib.Path):
+        results_dir.joinpath("weights.model").write_text(self.model)
+        results_dir.joinpath("config.json").touch()
+
 
 MODEL_1 = ModelIn(
     type="mock_disruption_cnn",

--- a/tests/models_fixtures.py
+++ b/tests/models_fixtures.py
@@ -131,9 +131,9 @@ async def setup_model_db(setup_model_samples, db_client):
 
     # Create temp files for each
     for _id in (model_id_1, model_id_2, model_id_3, model_id_4):
-        config.settings.models.cache_dir.joinpath(f"{_id}.model").write_text(
-            "Test Model"
-        )
+        results_dir = config.settings.models.cache_dir.joinpath(_id)
+        results_dir.mkdir(parents=True)
+        results_dir.joinpath("weights.model").write_text("Test Model")
     yield {
         "project_id": project_id,
         "sample_ids": sample_ids,

--- a/toktagger/api/models/base.py
+++ b/toktagger/api/models/base.py
@@ -14,6 +14,7 @@ import pydantic
 import uuid
 from collections import OrderedDict
 import logging
+import pathlib
 
 logger = logging.getLogger("ray")
 
@@ -102,14 +103,16 @@ class Model(ABC):
         return self.predict(samples=samples, params=params, data_params=data_params)
 
     @typing.final
-    def wrapped_save(self, file_stem: str) -> None:
+    def wrapped_save(self, results_dir: pathlib.Path) -> None:
         if not self._trained:
             raise RuntimeError("Cannot save a model before it has been trained!")
-        self.save(file_stem=file_stem)
+        self.save(results_dir=results_dir)
 
     @typing.final
-    def wrapped_load(self, file_path: str) -> None:
-        self.load(file_path=file_path)
+    def wrapped_load(
+        self, results_dir: pathlib.Path, weights_filename: str | None = None
+    ) -> None:
+        self.load(results_dir=results_dir, weights_filename=weights_filename)
         self._trained = True
 
     @typing.final
@@ -126,6 +129,17 @@ class Model(ABC):
         progress: float | None = None,
         score: float | None = None,
     ) -> None:
+        """Send progress updates during model training to the TokTagger server.
+
+        Parameters
+        ----------
+        training_status : typing.Literal[ "queued", "started", "failed", "completed", "aborted" ] | None, optional
+            The current stage of model training, by default None
+        progress : float | None, optional
+            How far through training the model currently is (percentage, 0-100), by default None
+        score : float | None, optional
+            A metric of how well the model is performing (such as accuracy or loss), by default None
+        """
         model_update = ModelUpdate(
             training_status=training_status, progress=progress, score=score
         )
@@ -137,6 +151,27 @@ class Model(ABC):
         annotations: list[list[Annotation]],
         train_val_test_split: typing.Tuple[float, float, float],
     ) -> None:
+        """Split annotations into training, validation and testing sets.
+
+        Parameters
+        ----------
+        samples : list[Sample]
+            The samples which this model is training on
+        annotations : list[list[Annotation]]
+            The annotations to split into groups
+        train_val_test_split : typing.Tuple[float, float, float]
+            The fraction of the total annotations to put in each of the training, validation and test sets respectively.
+            These should each be fractions which sum to 1.
+
+        Raises
+        ------
+        ValueError
+            Raised if annotations are missing for some samples provided
+        ValueError
+            Raised if the splits do not sum to 1
+        ValueError
+            Raised if the requested splits would leave no samples in the training set
+        """
         if len(samples) != len(annotations):
             raise ValueError("Annotations missing for some samples!")
         if not math.isclose(sum(train_val_test_split), 1):
@@ -195,6 +230,7 @@ class Model(ABC):
 
     @abstractmethod
     def define_model(self) -> None:
+        """Define and return your model architecture here."""
         pass
 
     @abstractmethod
@@ -204,8 +240,22 @@ class Model(ABC):
         annotations: list[list[Annotation]],
         params: pydantic.BaseModel | None = None,
     ) -> float:
-        # pass in list of samples and list of annotations
-        # return some measure of accuracy
+        """Train your model here.
+
+        Parameters
+        ----------
+        samples : list[Sample]
+            A list of samples to use when training the model.
+        annotations : list[list[Annotation]]
+            A list of lists of annotations, one list of annotations per sample.
+        params : pydantic.BaseModel | None, optional
+            User specified parameters to be used when training the model, by default None
+
+        Returns
+        -------
+        float
+            The score of the trained model, such as accuracy or loss.
+        """
         pass
 
     @abstractmethod
@@ -215,16 +265,49 @@ class Model(ABC):
         params: pydantic.BaseModel | None = None,
         data_params: DataParamTypes | None = None,
     ) -> list[list[AnnotationBase]]:
-        # pass in list of samples and params required
-        # returns list / array / tensor of predictions and uncertainties
+        """Predict over unseen samples with your model here.
+
+        Parameters
+        ----------
+        samples : list[Sample]
+            A list of samples to make predictions over
+        params : pydantic.BaseModel | None, optional
+            User specified parameters to be used when making predictions, by default None
+        data_params : DataParamTypes | None, optional
+            Data parameters to use when loading samples for the model to predict over, by default None
+
+        Returns
+        -------
+        list[list[AnnotationBase]]
+            A list of predicted annotations for each sample
+        """
         pass
 
     @abstractmethod
-    def save(self, file_stem: str) -> None:
+    def save(self, results_dir: pathlib.Path) -> None:
+        """Save the model
+
+        Parameters
+        ----------
+        results_dir : pathlib.Path
+            The path to a directory in the model cache where your model weights and accompanying information should be saved.
+        """
         pass
 
     @abstractmethod
-    def load(self, file_path: str) -> None:
+    def load(
+        self, results_dir: pathlib.Path, weights_filename: str | None = None
+    ) -> None:
+        """Load a pretrained model.
+
+        Parameters
+        ----------
+        results_dir : pathlib.Path
+            The path to a directory in the model cache where model weights should be loaded from.
+        weights_filename : str | None, optional
+            The name of the weights file within the above directory to load, by default None
+            Note that this is optional, but should take precedence if provided.
+        """
         pass
 
 

--- a/toktagger/api/models/base.py
+++ b/toktagger/api/models/base.py
@@ -232,7 +232,7 @@ class Model(ABC):
             )
 
     @abstractmethod
-    def define_model(self) -> None:
+    def define_model(self) -> typing.Any:
         """Define and return your model architecture here."""
         pass
 

--- a/toktagger/api/models/base.py
+++ b/toktagger/api/models/base.py
@@ -104,6 +104,9 @@ class Model(ABC):
 
     @typing.final
     def wrapped_save(self, results_dir: pathlib.Path) -> None:
+        # Make sure results_dir exists
+        results_dir.mkdir(parents=True, exist_ok=True)
+
         if not self._trained:
             raise RuntimeError("Cannot save a model before it has been trained!")
         self.save(results_dir=results_dir)

--- a/toktagger/api/models/disruption.py
+++ b/toktagger/api/models/disruption.py
@@ -370,7 +370,7 @@ class DisruptionCNN(Model):
 
     def load(self, results_dir: pathlib.Path, weights_filename: str | None = None):
         if weights_filename:
-            results_path = results_dir.joinpath("weights_filename")
+            results_path = results_dir.joinpath(weights_filename)
         else:
             results_path = results_dir.joinpath("weights.model")
 

--- a/toktagger/api/models/disruption.py
+++ b/toktagger/api/models/disruption.py
@@ -11,6 +11,7 @@ import typing
 from toktagger.api.models.base import Model, ModelRegistry
 import logging
 import pydantic
+import pathlib
 
 logger = logging.getLogger("ray")
 
@@ -364,8 +365,13 @@ class DisruptionCNN(Model):
             for i in range(len(samples))
         ]
 
-    def save(self, file_stem: str):
-        torch.save(self.model.state_dict(), f"{file_stem}.model")
+    def save(self, results_dir: pathlib.Path) -> None:
+        torch.save(self.model.state_dict(), results_dir.joinpath("weights.model"))
 
-    def load(self, file_path: str):
-        self.model.load_state_dict(torch.load(file_path, map_location="cpu"))
+    def load(self, results_dir: pathlib.Path, weights_filename: str | None = None):
+        if weights_filename:
+            results_path = results_dir.joinpath("weights_filename")
+        else:
+            results_path = results_dir.joinpath("weights.model")
+
+        self.model.load_state_dict(torch.load(results_path, map_location="cpu"))

--- a/toktagger/api/models/disruption.py
+++ b/toktagger/api/models/disruption.py
@@ -368,7 +368,9 @@ class DisruptionCNN(Model):
     def save(self, results_dir: pathlib.Path) -> None:
         torch.save(self.model.state_dict(), results_dir.joinpath("weights.model"))
 
-    def load(self, results_dir: pathlib.Path, weights_filename: str | None = None):
+    def load(
+        self, results_dir: pathlib.Path, weights_filename: str | None = None
+    ) -> None:
         if weights_filename:
             results_path = results_dir.joinpath(weights_filename)
         else:

--- a/toktagger/api/models/temp.py
+++ b/toktagger/api/models/temp.py
@@ -92,8 +92,10 @@ class VideoCNN(Model):
                 annotations.append(sample_anns)
         return annotations
 
-    def save(self, file_stem: str):
-        pathlib.Path(file_stem).with_suffix(".model").touch()
+    def save(self, results_dir: pathlib.Path) -> None:
+        results_dir.joinpath("weights.model").touch()
 
-    def load(self, file_path: str):
+    def load(
+        self, results_dir: pathlib.Path, weights_filename: str | None = None
+    ) -> None:
         self.model = None

--- a/toktagger/api/routers/models.py
+++ b/toktagger/api/routers/models.py
@@ -138,7 +138,7 @@ async def delete_models(
         )
 
         # And delete file from storage (if it exists - may not if the job failed)
-        model_dir = config.settings.models.cache_dir.joinpath(f"{model.id}")
+        model_dir = config.settings.models.cache_dir.joinpath(model.id)
         if model_dir.exists():
             shutil.rmtree(model_dir)
 

--- a/toktagger/api/routers/models.py
+++ b/toktagger/api/routers/models.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from collections import defaultdict
 import toktagger.api.config as config
 import pathlib
+import shutil
 
 # Only import large packages if models dependencies installed
 if models_dependencies_installed():
@@ -137,9 +138,9 @@ async def delete_models(
         )
 
         # And delete file from storage (if it exists - may not if the job failed)
-        config.settings.models.cache_dir.joinpath(f"{model.id}.model").unlink(
-            missing_ok=True
-        )
+        model_dir = config.settings.models.cache_dir.joinpath(f"{model.id}")
+        if model_dir.exists():
+            shutil.rmtree(model_dir)
 
 
 @router.get("/models/{model_type}/train")

--- a/toktagger/api/worker.py
+++ b/toktagger/api/worker.py
@@ -17,6 +17,7 @@ from toktagger.api.core.sender import (
     send_model_updates,
 )
 import logging
+import shutil
 from platformdirs import user_cache_dir
 import pydantic
 
@@ -141,6 +142,7 @@ def train_model(
     use_gpu: bool = False,
 ):  # TODO: do we want to support retraining where we only get annotations not previously put into model?
     model_actor = get_actor(project=project, model=model, use_gpu=use_gpu)
+    results_dir = pathlib.Path(os.environ["MODEL_STORAGE"]).joinpath(str(model.id))
     try:
         logger.info(f"Running model training for project {project.id}")
         model_actor.log_progress.remote(training_status="started", progress=0)
@@ -151,9 +153,9 @@ def train_model(
         # Wait for train task to complete
         score = ray.get(train_task)
 
-        results_dir = pathlib.Path(os.environ["MODEL_STORAGE"]).joinpath(str(model.id))
         results_dir.mkdir(parents=True)
-        model_actor.wrapped_save.remote(results_dir)
+        save_task = model_actor.wrapped_save.remote(results_dir)
+        ray.get(save_task)  # Block until save is done
 
         send_model_updates(
             project_id=project.id,
@@ -173,6 +175,11 @@ def train_model(
             model_id=model.id,
             updates=ModelUpdate(training_status="failed"),
         )
+
+        # Also delete directory of results, if it has already been created
+        if results_dir.exists():
+            shutil.rmtree(results_dir)
+
         raise e
 
 

--- a/toktagger/api/worker.py
+++ b/toktagger/api/worker.py
@@ -106,7 +106,7 @@ def load_model(
     # Try loading actor with weights file, catch and reraise any errors
     try:
         load_temp_weights_task = model_actor.wrapped_load.remote(
-            weights_path.parent, weights_path.name
+            results_dir=weights_path.parent, weights_filename=weights_path.name
         )
         ray.get(load_temp_weights_task)
     except Exception as e:

--- a/toktagger/api/worker.py
+++ b/toktagger/api/worker.py
@@ -153,7 +153,6 @@ def train_model(
         # Wait for train task to complete
         score = ray.get(train_task)
 
-        results_dir.mkdir(parents=True)
         save_task = model_actor.wrapped_save.remote(results_dir)
         ray.get(save_task)  # Block until save is done
 

--- a/toktagger/api/worker.py
+++ b/toktagger/api/worker.py
@@ -69,11 +69,9 @@ def get_actor(project: Project, model: Model, use_gpu: bool):
             )
         )
 
-        model_path = next(
-            pathlib.Path(os.environ["MODEL_STORAGE"]).glob(f"{str(model.id)}*"), None
-        )
-        if model_path:
-            ml_model.wrapped_load.remote(model_path)
+        results_dir = pathlib.Path(os.environ["MODEL_STORAGE"]).joinpath(str(model.id))
+        if results_dir.exists():
+            ml_model.wrapped_load.remote(results_dir)
         else:
             logger.debug("No saved weights found, initializing blank model")
 
@@ -91,10 +89,6 @@ def load_model(
         updates=ModelUpdate(training_status="started"),
     )
 
-    # Make sure model storage location in cache dir exists
-    model_dir = pathlib.Path(os.environ["MODEL_STORAGE"])
-    model_dir.mkdir(exist_ok=True)
-
     # Check worker can see weights file
     if not weights_path.exists():
         send_model_updates(
@@ -110,7 +104,9 @@ def load_model(
     model_actor = get_actor(project=project, model=model, use_gpu=False)
     # Try loading actor with weights file, catch and reraise any errors
     try:
-        load_temp_weights_task = model_actor.wrapped_load.remote(str(weights_path))
+        load_temp_weights_task = model_actor.wrapped_load.remote(
+            weights_path.parent, weights_path.name
+        )
         ray.get(load_temp_weights_task)
     except Exception as e:
         logger.error(e)
@@ -125,10 +121,11 @@ def load_model(
             "message": f"Failed to load weights - {str(e)}",
         }
 
-    # Save the model with the correct file name, delete temporary file
-    save_weights_task = model_actor.wrapped_save.remote(
-        model_dir.joinpath(str(model.id))
-    )
+    # Save the model with the correct dir path
+    results_dir = pathlib.Path(os.environ["MODEL_STORAGE"]).joinpath(str(model.id))
+    results_dir.mkdir(parents=True)
+
+    save_weights_task = model_actor.wrapped_save.remote(results_dir)
     ray.get(save_weights_task)
 
     return {"project_id": project.id, "model_id": model.id, "message": None}
@@ -154,9 +151,9 @@ def train_model(
         # Wait for train task to complete
         score = ray.get(train_task)
 
-        model_dir = pathlib.Path(os.environ["MODEL_STORAGE"])
-        model_dir.mkdir(exist_ok=True)  # Do i need to do this every time?
-        model_actor.wrapped_save.remote(model_dir.joinpath(str(model.id)))
+        results_dir = pathlib.Path(os.environ["MODEL_STORAGE"]).joinpath(str(model.id))
+        results_dir.mkdir(parents=True)
+        model_actor.wrapped_save.remote(results_dir)
 
         send_model_updates(
             project_id=project.id,

--- a/toktagger/api/worker.py
+++ b/toktagger/api/worker.py
@@ -124,7 +124,6 @@ def load_model(
 
     # Save the model with the correct dir path
     results_dir = pathlib.Path(os.environ["MODEL_STORAGE"]).joinpath(str(model.id))
-    results_dir.mkdir(parents=True)
 
     save_weights_task = model_actor.wrapped_save.remote(results_dir)
     ray.get(save_weights_task)


### PR DESCRIPTION
Changes model storage to now make a directory available with name equal to the model ID, so that more than one file can be saved for a given model.

`load()` now accepts two parameters, the storage directory, and (optionally) a weights file name. If the weights file name is provided, it should take precedence, otherwise fallback to what the model's `save()` method will have created.

See example implementation in the `disruption_cnn` model

Note that when loading files via the UI, we will still only support the loading of a single weights file (for now...)