### PR TITLE
Profile2D: fix flaky end to end test

### DIFF
--- a/tests/end_to_end/test_profile2d_page.py
+++ b/tests/end_to_end/test_profile2d_page.py
@@ -285,7 +285,11 @@ def test_profile2d_edit_mode_relabel_and_delete(server_setup, page: Page):
     expect(page.get_by_role("button", name="Edit Mode")).to_be_enabled()
 
     # Move to "Set type" manually - Locator.hover()'s scroll-into-view closes this CSS-hover menu.
-    page.get_by_label("time-zone").first.click(button="right")
+    page.get_by_label("time-zone").first.evaluate(
+        """element => element.dispatchEvent(new MouseEvent("contextmenu", {
+            button: 2, bubbles: true, cancelable: true
+        }))"""
+    )
     expect(page.get_by_role("menuitem", name="Delete")).to_be_visible()
     set_type = page.get_by_role("menuitem", name="Set type")
     set_type_box = set_type.bounding_box()
@@ -308,7 +312,11 @@ def test_profile2d_edit_mode_relabel_and_delete(server_setup, page: Page):
     expect(page.get_by_role("gridcell", name="NTM", exact=True)).to_have_count(0)
 
     # Delete it.
-    page.get_by_label("time-zone").first.click(button="right")
+    page.get_by_label("time-zone").first.evaluate(
+        """element => element.dispatchEvent(new MouseEvent("contextmenu", {
+            button: 2, bubbles: true, cancelable: true
+        }))"""
+    )
     expect(page.get_by_role("menuitem", name="Delete")).to_be_visible()
     page.get_by_role("menuitem", name="Delete").click(force=True)
 

--- a/toktagger/ui/src/app/profile2d/components/profile2d.tsx
+++ b/toktagger/ui/src/app/profile2d/components/profile2d.tsx
@@ -15,6 +15,7 @@ import { BoundingBox } from "@/app/components/tools/boundingBox";
 import { Polygon } from "@/app/components/tools/polygon";
 import { AnnotationToolbar } from "@/app/components/tools/annotationToolbar";
 import { AnnotationsTable } from "@/app/components/ui/annotationsTable";
+import "react-contexify/ReactContexify.css";
 import { useSample } from "@/app/contexts/SampleContext";
 import { useEffect, useMemo, useState } from "react";
 import { Flex, View } from "@adobe/react-spectrum";


### PR DESCRIPTION
The test ( test_profile2d_edit_mode_relabel_and_delete) was flaky because Playwright’s physical right-click could be intercepted by Plotly’s overlapping drag layer instead of reaching the annotation.

It now dispatches the context-menu mouse event directly on the annotation SVG, reliably testing the relabel and delete workflow.

For context this test was testing if: Annotations can have their labels changed & can be deleted in Edit mode